### PR TITLE
Add SELinux paramater to satellite6-installer job

### DIFF
--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -28,6 +28,11 @@
                   <li><strong>ISO</strong>: Install from an ISO image from latest stable internal compose</li>
                   <li><strong>UPSTREAM</strong>: Install from latest community build</li>
                 </ul>
+        - choice:
+            name: SELINUX_MODE
+            choices:
+                - 'enforcing'
+                - 'permissive'
     scm:
         - git:
             url: https://github.com/SatelliteQE/automation-tools.git


### PR DESCRIPTION
This parameter will allow control if the user want to install Satellite
6 in permissive or enforcing SELinux mode.

Closes #2