### PR TITLE
Improve satellite6-installer job

### DIFF
--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -33,6 +33,17 @@
             choices:
                 - 'enforcing'
                 - 'permissive'
+        - bool:
+            name: FIX_HOSTNAME
+            default: true
+            description: |
+                Run a task to updates /etc/hosts with FQDN and IP
+        - bool:
+            name: PARTITION_DISK
+            default: false
+            description: |
+                Run a task to re-partition disk to increase the size of /root
+                to handle synchronization of larger repositories
     scm:
         - git:
             url: https://github.com/SatelliteQE/automation-tools.git

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -1,20 +1,24 @@
 pip install -U -r requirements.txt
 
-if [ $BUILD_USER_ID = "omaciel" ]; then
-    fab -i ~/.ssh/id_hudson_dsa -H root@$SERVER_HOSTNAME fix_hostname partition_disk
+if [ ${FIX_HOSTNAME} = "true" ]; then
+    fab -i ~/.ssh/id_hudson_dsa -H root@${SERVER_HOSTNAME} fix_hostname
+fi
+
+if [ ${PARTITION_DISK} = "true" ]; then
+    fab -i ~/.ssh/id_hudson_dsa -H root@${SERVER_HOSTNAME} partition_disk
 fi
 
 # Figure out what version of RHEL the server uses
-OS_VERSION=$(fab -i ~/.ssh/id_hudson_dsa -H root@$SERVER_HOSTNAME distro_info | grep "rhel \d" | cut -d ' ' -f 2)
+OS_VERSION=$(fab -i ~/.ssh/id_hudson_dsa -H root@${SERVER_HOSTNAME} distro_info | grep "rhel [[:digit:]]" | cut -d ' ' -f 2)
 
 # ISOs require a specific URL
-if [ $DISTRIBUTION = "ISO" ]; then
-    export ISO_URL="${REPO_BASE_URL}/Satellite/latest-stable-Satellite-6.0-RHEL-${OS_VERSION}/compose/Satellite/x86_64/iso/"
+if [ ${DISTRIBUTION} = "ISO" ]; then
+    export ISO_URL="${REPO_BASE_URL}/Satellite/latest-stable-Satellite-6.1-RHEL-${OS_VERSION}/compose/Satellite/x86_64/iso/"
 fi
 
 # This is only used for downstream builds
-if [ $DISTRIBUTION = "DOWNSTREAM" ]; then
-    export BASE_URL="${REPO_BASE_URL}/Satellite/latest-stable-Satellite-6.0-RHEL-${OS_VERSION}/compose/Satellite/x86_64/os/"
+if [ ${DISTRIBUTION} = "DOWNSTREAM" ]; then
+    export BASE_URL="${REPO_BASE_URL}/Satellite/latest-stable-Satellite-6.1-RHEL-${OS_VERSION}/compose/Satellite/x86_64/os/"
 fi
 
-fab -i ~/.ssh/id_hudson_dsa -H root@$SERVER_HOSTNAME product_install:satellite6-${DISTRIBUTION}
+fab -i ~/.ssh/id_hudson_dsa -H root@${SERVER_HOSTNAME} product_install:satellite6-${DISTRIBUTION}


### PR DESCRIPTION
Add boolean parameters for running fix_hostname and partition_disk
tasks. This closes #7.

Update URLs to install Satellite 6.1 instead of 6.0.

Update all variables from installer.sh script to use the notation
${VAR_NAME}. And also fix the grep command when getting the OS_VERSION,
thanks @Ichimonji10 for figuring the regex issue out.