### PR TITLE
Fix external_url automation config

### DIFF
--- a/scripts/automation.sh
+++ b/scripts/automation.sh
@@ -29,6 +29,6 @@ sed -i "s|manifest\.cert_url.*|manifest\.cert_url=$FAKE_MANIFEST_CERT_URL|" robo
 sed -i "s/provisioning_server.*/provisioning_server=$PROVISIONING_SERVER/" robottelo.properties
 
 # Docker configuration
-sed -i "s/external_url.*/external_url=$DOCKER_EXTERNAL_URL/" robottelo.properties
+sed -i "s|external_url.*|external_url=$DOCKER_EXTERNAL_URL|" robottelo.properties
 
 make test-foreman-$ENDPOINT


### PR DESCRIPTION
Use | separator for sed instead of / because external_url config will
receive and URL which contains some /.