### PR TITLE
Turn off smoke robottelo option for API tests

### DIFF
--- a/jobs/product-automation.yaml
+++ b/jobs/product-automation.yaml
@@ -15,11 +15,6 @@
                 - '2'
                 - '1'
         - choice:
-            name: SMOKE
-            choices:
-                - '1'
-                - '0'
-        - choice:
             name: LOCALE
             choices:
                 - en_US.UTF-8

--- a/scripts/automation.sh
+++ b/scripts/automation.sh
@@ -8,6 +8,12 @@ if [ "$PRODUCT" = 'satellite6' ]; then
     PRODUCT='sat'
 fi
 
+# API automation will run all data-driven tests
+if [ "$ENDPOINT" = 'api' ]; then
+    SMOKE=0
+else
+    SMOKE=1
+fi
 
 cp robottelo.properties.sample robottelo.properties
 


### PR DESCRIPTION
This will make Robottelo run all data-driven tests for API instead of
randomly selecting just one data item.