### PR TITLE
Move subscription information to config files

### DIFF
--- a/jobs/defaults.yaml
+++ b/jobs/defaults.yaml
@@ -2,16 +2,3 @@
     name: default-wrappers
     wrappers:
         - ansicolor
-        - credentials-binding:
-            - text:
-                credential-id: d5d498a9-029b-416d-a839-98694e22f534
-                variable: REPO_BASE_URL
-            - text:
-                credential-id: 3b1e3e6f-0536-4a3d-b1ab-9f1db6c0d908
-                variable: RHN_USERNAME
-            - text:
-                credential-id: 441b4de0-96c6-479e-8dfa-dd11d84f09b2
-                variable: RHN_PASSWORD
-            - text:
-                credential-id: e13aa619-3c93-4711-b2db-dc46032a3e1e
-                variable: RHN_POOLID

--- a/jobs/product-automation.yaml
+++ b/jobs/product-automation.yaml
@@ -95,12 +95,14 @@
         - default-wrappers
         - config-file-provider:
             files:
+                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1421863970654
+                  variable: FAKE_CERT_CONFIG
                 - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1426617852908
                   variable: PROXY_CONFIG
                 - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1421176025129
                   variable: PROVISIONING_CONFIG
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1421863970654
-                  variable: FAKE_CERT_CONFIG
+                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1426679847040
+                  variable: SUBSCRIPTION_CONFIG
         - inject:
             properties-content: |
                 DISTRO={os}
@@ -116,6 +118,7 @@
                 source $FAKE_CERT_CONFIG
                 source $PROVISIONING_CONFIG
                 source $PROXY_CONFIG
+                source $SUBSCRIPTION_CONFIG
                 if [ "$DISTRIBUTION" = 'satellite6-zstream' ]; then
                     DISTRIBUTION='satellite6-downstream'
                 fi

--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -64,6 +64,8 @@
             files:
                 - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1426617852908
                   variable: PROXY_CONFIG
+                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1426679847040
+                  variable: SUBSCRIPTION_CONFIG
         - default-wrappers
     builders:
         - shining-panda:

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -1,6 +1,7 @@
 pip install -U -r requirements.txt
 
 source ${PROXY_CONFIG}
+source ${SUBSCRIPTION_CONFIG}
 
 if [ ${FIX_HOSTNAME} = "true" ]; then
     fab -i ~/.ssh/id_hudson_dsa -H root@${SERVER_HOSTNAME} fix_hostname


### PR DESCRIPTION
After updating Jenkins, the credentials started being passed as a
sequence of `*`. To fix that was needed to just enter in the
configuration page for the provisioning jobs and click on save right
way, after that the credentials magically started working again.

To fix the above issue, the subscription was moved to a config file
which is sourced where needed (provisioning jobs as
satellite6-installer). This way no manual work will be needed when
updating the jobs using jenkins-job-builder. Also the credentials
information will be visible by jenkins admins which will make easier to
know what value they are set and update if needed.