### PR TITLE
Add option to setup fake manifest certificate

### DIFF
--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -50,6 +50,12 @@
             description: |
                 Run a task to re-partition disk to increase the size of /root
                 to handle synchronization of larger repositories
+        - bool:
+            name: SETUP_FAKE_MANIFEST_CERTIFICATE
+            default: false
+            description: |
+                Run a task to install a fake manifest certificate. Run this if
+                you are planning to run Robottelo tests.
     scm:
         - git:
             url: https://github.com/SatelliteQE/automation-tools.git
@@ -62,6 +68,8 @@
         - build-user-vars
         - config-file-provider:
             files:
+                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1421863970654
+                  variable: FAKE_CERT_CONFIG
                 - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1426617852908
                   variable: PROXY_CONFIG
                 - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1426679847040

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -25,3 +25,8 @@ if [ ${DISTRIBUTION} = "DOWNSTREAM" ]; then
 fi
 
 fab -i ~/.ssh/id_hudson_dsa -H root@${SERVER_HOSTNAME} product_install:satellite6-${DISTRIBUTION}
+
+if [ ${SETUP_FAKE_MANIFEST_CERTIFICATE} = "true" ]; then
+    source $FAKE_CERT_CONFIG
+    fab -i ~/.ssh/id_hudson_dsa -H root@${SERVER_HOSTNAME} setup_fake_manifest_certificate
+fi


### PR DESCRIPTION
Add option on satellite6-installer job to allow opting to setup a fake
manifest certificate. This will allow run Robottelo tests against the
machines with Satellite installed by the job.