### PR TITLE
Update Satellite 6 repositories URLs

### DIFF
--- a/jobs/product-automation.yaml
+++ b/jobs/product-automation.yaml
@@ -268,19 +268,46 @@
     description: Triggers automation for Satellite 6
     parameters:
         - string:
-            name: RHEL6_BASE_URL
+            name: RHEL6_OS_URL
             description: |
-                End with the arch. Example: http://example.com/path/to/Satellite/Satellite-6.1.0-RHEL-6-20150311.1/compose/Satellite/x86_64
+                Leave it blank to install the latest stable.
         - string:
-            name: RHEL7_BASE_URL
+            name: RHEL7_OS_URL
             description: |
-                End with the arch. Example: http://example.com/path/to/Satellite/Satellite-6.1.0-RHEL-7-20150311.1/compose/Satellite/x86_64
+                Leave it blank to install the latest stable.
+        - string:
+            name: RHEL6_ISO_URL
+            description: |
+                Leave it blank to install the latest stable.
+        - string:
+            name: RHEL7_ISO_URL
+            description: |
+                Leave it blank to install the latest stable.
         - choice:
             name: SELINUX_MODE
             choices:
                 - 'enforcing'
                 - 'permissive'
+    wrappers:
+        - config-file-provider:
+            files:
+                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1430942714372
+                  variable: SATELLITE6_REPOS_URLS
     builders:
+        - inject:
+            script-content: |
+                if [ -z RHEL6_OS_URL ]; then
+                    export RHEL6_OS_URL="${SATELLITE6_RHEL6_OS}"
+                fi
+                if [ -z RHEL7_OS_URL ]; then
+                    export RHEL7_OS_URL="${SATELLITE6_RHEL7_OS}"
+                fi
+                if [ -z RHEL6_ISO_URL ]; then
+                    export RHEL6_ISO_URL="${SATELLITE6_RHEL6_ISO}"
+                fi
+                if [ -z RHEL7_ISO_URL ]; then
+                    export RHEL7_ISO_URL="${SATELLITE6_RHEL7_ISO}"
+                fi
         - trigger-builds:
             - project: satellite6-provisioning-downstream-rhel66
               predefined-parameters: |

--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -72,6 +72,8 @@
                   variable: FAKE_CERT_CONFIG
                 - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1426617852908
                   variable: PROXY_CONFIG
+                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1430942714372
+                  variable: SATELLITE6_REPOS_URLS
                 - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1426679847040
                   variable: SUBSCRIPTION_CONFIG
         - default-wrappers

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -1,6 +1,7 @@
 pip install -U -r requirements.txt
 
 source ${PROXY_CONFIG}
+source ${SATELLITE6_REPOS_URLS}
 source ${SUBSCRIPTION_CONFIG}
 
 if [ ${FIX_HOSTNAME} = "true" ]; then
@@ -16,12 +17,12 @@ OS_VERSION=$(fab -i ~/.ssh/id_hudson_dsa -H root@${SERVER_HOSTNAME} distro_info 
 
 # ISOs require a specific URL
 if [ ${DISTRIBUTION} = "ISO" ]; then
-    export ISO_URL="${REPO_BASE_URL}/Satellite/latest-stable-Satellite-6.1-RHEL-${OS_VERSION}/compose/Satellite/x86_64/iso/"
+    export ISO_URL="${SATELLITE6_ISO_REPO}"
 fi
 
 # This is only used for downstream builds
 if [ ${DISTRIBUTION} = "DOWNSTREAM" ]; then
-    export BASE_URL="${REPO_BASE_URL}/Satellite/latest-stable-Satellite-6.1-RHEL-${OS_VERSION}/compose/Satellite/x86_64/os/"
+    export BASE_URL="${SATELLITE6_OS_REPO}"
 fi
 
 fab -i ~/.ssh/id_hudson_dsa -H root@${SERVER_HOSTNAME} product_install:satellite6-${DISTRIBUTION}


### PR DESCRIPTION
The repositories are now being served in a different URL. Update the
jobs to match the new place.