### PR TITLE
Add script for managing Jenkins plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+help:
+	@echo "Please use \`make <target>' where <target> is one of:"
+	@echo "  help   to show this message"
+	@echo "  setup  to update jobs and install missing plugins"
+
+setup:
+	jenkins-jobs --conf jenkins_jobs.ini update jobs
+	scripts/manage_plugins.py install $$(cat plugins.txt)
+
+.PHONY: help setup

--- a/plugins.txt
+++ b/plugins.txt
@@ -1,0 +1,3 @@
+ansicolor
+config-file-provider
+shiningpanda

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 jenkins-job-builder
+requests

--- a/scripts/manage_plugins.py
+++ b/scripts/manage_plugins.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+"""Manage Jenkins plugins.
+
+This module functions both as a stand-alone command-line script and as an
+importable Python library. It contains tools for managing the plugins on a
+Jenkins server. This script makes use of the "jenkins" section of
+``jenkins_jobs.ini``.
+
+"""
+from __future__ import print_function
+from argparse import ArgumentParser
+from xml.etree import ElementTree
+import os
+import requests
+
+from sys import version_info
+if version_info.major == 2:
+    from ConfigParser import ConfigParser  # pylint:disable=import-error
+else:
+    from configparser import ConfigParser  # pylint:disable=import-error
+
+
+def main():
+    """Parse command-line arguments."""
+    parser = ArgumentParser(description='Manage Jenkins plugins.')
+    subparsers = parser.add_subparsers()
+
+    install_parser = subparsers.add_parser(
+        'install',
+        help=(
+            'Install the named plugin(s). A specific plugin version may be '
+            'provided by appending "@version_number" to the end of a plugin '
+            'name. If no plugin version is provided, "@default" is appended.'
+        ),
+    )
+    install_parser.set_defaults(func=install)
+    install_parser.add_argument('plugins', metavar='plugin', nargs='+')
+
+    uninstall_parser = subparsers.add_parser(
+        'uninstall',
+        help='Uninstall the named plugin(s).',
+    )
+    uninstall_parser.set_defaults(func=uninstall)
+    uninstall_parser.add_argument('plugins', metavar='plugin', nargs='+')
+
+    query_parser = subparsers.add_parser(
+        'query',
+        help='List installed plugins.',
+    )
+    query_parser.set_defaults(func=query)
+    query_parser_group = query_parser.add_mutually_exclusive_group()
+    query_parser_group.add_argument(
+        '--implicit',
+        action='count',
+        help='Only show plugins installed implicitly (as dependencies).',
+    )
+    query_parser_group.add_argument(
+        '--explicit',
+        action='count',
+        help='Only show plugins installed explicitly (not as dependencies).',
+    )
+
+    args = parser.parse_args()
+    result = args.func(args)
+    if args.func == query:
+        for plugin in result:
+            print(plugin)
+    elif args.func == install:
+        print(
+            'Plugins are being installed. You may need to restart Jenkins '
+            'when all plugins are done installing.'
+        )
+    elif args.func == uninstall:
+        print(
+            'Plugins are being uninstalled. You may need to restart Jenkins '
+            'when all plugins are done uninstalling.'
+        )
+
+
+def install(args):
+    """Install one or more plugins."""
+    config = _get_config()
+    xml_root = ElementTree.Element('jenkins')
+    for plugin in args.plugins:
+        if '@' not in plugin:
+            plugin = plugin + '@default'
+        ElementTree.SubElement(xml_root, 'install', {'plugin': plugin})
+    response = requests.post(
+        '{0}/pluginManager/installNecessaryPlugins'.format(config['url']),
+        ElementTree.tostring(xml_root),
+        auth=config['auth'],
+        headers={'content-type': 'text/xml'},
+        verify=False,
+    )
+    response.raise_for_status()
+
+
+def uninstall(args):
+    """Uninstall one or more plugins."""
+    config = _get_config()
+    for plugin in args.plugins:
+        requests.post(
+            '{0}/pluginManager/plugin/{1}/doUninstall'.format(
+                config['url'],
+                plugin,
+            ),
+            auth=config['auth'],
+            verify=False,
+        ).raise_for_status()
+
+
+def query(args):
+    """Get information about plugins.
+
+    :returns: An iterable of strings in the form
+        ``'plugin-name@plugin-version'``.
+
+    """
+    config = _get_config()
+    response = requests.get(
+        '{0}/pluginManager/api/json?depth=2'.format(config['url']),
+        auth=config['auth'],
+        verify=False,
+    )
+    response.raise_for_status()
+    plugins = response.json()['plugins']
+
+    # If the user just wants a list of all plugins, our job is easy.
+    if args.explicit is None and args.implicit is None:
+        return set((
+            '{}@{}'.format(plugin['shortName'], plugin['version'])
+            for plugin in plugins
+        ))
+
+    # Here, we enumerate explicitly- and implicitly-installed plugins. Our
+    # strategy is to gather all plugins into the "explicit" set, then move them
+    # to the "implicit" set as needed. We do this because not-installed plugins
+    # may be listed as dependencies. Here's an example of a dependency:
+    #
+    #   {"optional" : false, "shortName" : "matrix-auth", "version" : "1.0.2"}
+    #
+    exp_names = set((plugin['shortName'] for plugin in plugins))
+    imp_names = set()
+    for plugin in plugins:
+        for dependency in plugin['dependencies']:
+            if (dependency['optional'] is False and
+                    dependency['shortName'] in exp_names):
+                exp_names.remove(dependency['shortName'])
+                imp_names.add(dependency['shortName'])
+
+    # Finally — compile a set of 'plugin-name@plugin-version' strings!
+    target = exp_names if args.explicit is not None else imp_names
+    return set((
+        '{}@{}'.format(plugin['shortName'], plugin['version'])
+        for plugin in plugins
+        if plugin['shortName'] in target
+    ))
+
+
+def _get_config():
+    """Read configuration options from the ``jenkins_jobs.ini`` config file.
+
+    Parse the ``jenkins_jobs.ini`` configuration file and return a dict in the
+    following form::
+
+        {
+            'auth': ('username', 'password'),
+            'url': …,
+        }
+
+    """
+    config = ConfigParser()
+    reader = config.readfp if version_info.major == 2 else config.read_file  # noqa pylint:disable=no-member
+    with open(
+        os.path.join(os.path.dirname(__file__), os.pardir, 'jenkins_jobs.ini')
+    ) as handle:
+        reader(handle)
+    if version_info.major == 2:
+        return {
+            'auth': (
+                config.get('jenkins', 'user'),
+                config.get('jenkins', 'password')
+            ),
+            'url': config.get('jenkins', 'url'),
+        }
+    else:
+        return {
+            'auth': (config['jenkins']['user'], config['jenkins']['password']),
+            'url': config['jenkins']['url'],
+        }
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Related to #27:

> Our Jenkins installation makes use of several plugins. robottelo-ci should be
> able to manage the plugins that Jenkins has installed. I envision robottelo-ci
> being able to accomplish the following tasks:
>
> * Given a freshly installed Jenkins instance, make that Jenkins instance install
>   a correct set of plugins.
> * Given an existing Jenkins instance, make that Jenkins instance install any
>   missing plugins and remove any extra plugins.
> * Given an existing Jenkins instance, make that Jenkins instance upgrade or
>   downgrade its installed plugins.

Here's an example of the script in action:

    $ scripts/manage_plugins.py query | grep -i git
    github-api@1.67
    git-server@1.6
    git-client@1.17.1
    $ scripts/manage_plugins.py install git
    Plugins are being installed. You may need to restart Jenkins when all plugins are done installing.
    $ scripts/manage_plugins.py query | grep -i git
    github-api@1.67
    git@2.3.5
    git-server@1.6
    git-client@1.17.1
    $ sudo systemctl restart jenkins
    $ scripts/manage_plugins.py query | grep -i git
    github-api@1.67
    github@1.11.3
    git@2.3.5
    git-server@1.6
    git-client@1.17.1
    $ scripts/manage_plugins.py uninstall git
    $ sudo systemctl restart jenkins
    $ scripts/manage_plugins.py query | grep -i git
    github-api@1.67
    git-server@1.6
    git-client@1.17.1

Also add a make task that updates a Jenkins server's jobs and installs/updates
all plugins, all in one go. `plugins.txt` was created by running
`scripts/manage_plugins.py query --explicit` on a live Jenkins instance.