### PR TITLE
Allow satellite6-installer to install Sat 6 Beta

### DIFF
--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -16,15 +16,17 @@
         - choice:
             name: DISTRIBUTION
             choices:
-                - CDN
                 - DOWNSTREAM
+                - CDN
+                - BETA
                 - ISO
                 - UPSTREAM
             description: |
                 <p>Choose the distribution type:</p>
                 <ul>
-                  <li><strong>CDN</strong>: Install from CDN</li>
                   <li><strong>DOWNSTREAM</strong>: Install from latest stable internal compose</li>
+                  <li><strong>CDN</strong>: Install from CDN</li>
+                  <li><strong>BETA</strong>: Install from CDN, using the beta repository</li>
                   <li><strong>ISO</strong>: Install from an ISO image from latest stable internal compose</li>
                   <li><strong>UPSTREAM</strong>: Install from latest community build</li>
                 </ul>


### PR DESCRIPTION
Add option to satellite6-installer job to allow it install Satellite 6
Beta from CDN.

Closes #35

This depends on https://github.com/SatelliteQE/automation-tools/pull/194