### PR TITLE
Satellite Upgrade automation job

### DIFF
--- a/jobs/satellite6-upgrader.yaml
+++ b/jobs/satellite6-upgrader.yaml
@@ -1,0 +1,67 @@
+- job:
+    name: 'satellite6-upgrader'
+    concurrent: false
+    display-name: 'Satellite6-Upgrader'
+    description: |
+        <p> This job Upgrades older version of Satellite 6 on the pre-installed image of Openstack.</p>
+        <p> Please make sure that the following <strong>ssh-key</strong> of jenkins has been added in your <strong>openstack project</strong>.</p>
+        <p><strong>SSH KEY:</strong></p>
+        <pre>
+          ssh-dss AAAAB3NzaC1kc3MAAACBAP2+EVkCT6dJzwL5LFDX0ACzbtlDasmpXbC5dpPNiWmADfdpRdDjWtVA/xjbSOT5tTuLr5fi6cQ2VMLNgVoQUT7tlPAJJU5Z7BngR6CkmonSlczLWbqyJVxg7At/o/kzzYFLE+i1+ReGlXasv4kOlPxhwhqm/wO0hzdImcc866qfAAAAFQDZ8h1+tp6S6KkAahfQUBfgrYhXZQAAAIBJUgNuQZw4ZJ81CPmYDkkYrGbMKxlPn7p/Mycxz+pZi6GbLuaY8rzbhiwS1JcOpUKuB0r4PX6qUoQvhRYZdhfaSEGX81K/3EGpjbzvcFSXa/8ymCcvw9oDoFFV6HWtWxEbjmy9kGrmHMeyFfFAK/tvNbwxDnn2usA4P7UX2NrqUgAAAIEAoVFEn7VZOn7mZZGkBa9Zrtm4AOQEbqd03UoYE1til96Z0Hja8rs6ilqYwuT57VzoePh2uIPfCgzeUxQ+RDjku3YLBsMNRwz3yS49iNiRWF1PAfqscLYyHAFPvvxDE1D/5dHtQGkad618nepycGf+cuSNzZjJdbbbT+qDCm+K6PY= hudson@statler.usersys.redhat.com
+        </pre>
+        <p> If this ssh key is not added already in your openstack project, please add it before running this job. Else the job will fail.</p>
+    node: sesame
+    parameters:
+        - choice:
+            name: PRODUCT
+            choices:
+                - satellite
+        - choice:
+            name: OS
+            choices:
+                - rhel_7
+                - rhel_6
+        - string:
+            name: INSTANCE_NAME 
+            description: "Openstack Instance name to create on openstack and to run upgrade."
+        - string:
+            name: IMAGE_NAME
+            description: |
+                Openstack Image name using which the the above instance will be created. The image should have older satellite version installed to upgrade.
+                <p><strong>Please make sure that there is no other instance running on openstack with same Image name. Else the results may vary or fail.</strong></p>
+        - choice:
+            name: IMAGE_FLAVOR
+            choices:
+                - m1.large
+                - m1.xlarge
+            description: "Choose the instance flavor/size to create on openstack. Prefer <strong>m1.large</strong>"
+        - string:
+            name: SSH_KEY_NAME
+            description: "The <strong>name</strong> of jenkins ssh-key, added in openstack project."
+    scm:
+        - git:
+            url: https://github.com/SatelliteQE/automation-tools.git
+            branches:
+                - origin/master
+            skip-tag: true
+    wrappers:
+        - build-name:
+            name: '#${BUILD_NUMBER}  ${ENV,var="PRODUCT"}_${ENV,var="OS"}_Upgrade'
+        - build-user-vars
+        - config-file-provider:
+            files:
+                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1439296949513
+                  variable: OPENSTACK_CONFIG
+                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1430942714372
+                  variable: SATELLITE6_REPOS_URLS
+                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1426679847040
+                  variable: SUBSCRIPTION_CONFIG
+        - default-wrappers
+    builders:
+          - shining-panda:
+              build-environment: virtualenv
+              python-version: System-CPython-2.7
+              clear: true
+              nature: shell
+              command:
+                !include-raw satellite6_upgrader.sh

--- a/scripts/satellite6_upgrader.sh
+++ b/scripts/satellite6_upgrader.sh
@@ -1,0 +1,18 @@
+pip install -U -r requirements.txt
+
+# Set OS version for further use
+if [ "${OS}" = 'rhel_7' ]; then
+        export OS_VERSION='7'
+elif [ "${OS}" = 'rhel_6' ]; then
+        export OS_VERSION='6'
+fi
+
+# Source the Variables from files
+source "${OPENSTACK_CONFIG}"
+source "${SATELLITE6_REPOS_URLS}"
+source "${SUBSCRIPTION_CONFIG}"
+
+# Export required Environment variables
+export BASE_URL="${SATELLITE6_OS_REPO}"
+
+fab -i ~/.ssh/id_hudson_dsa -u root product_upgrade:"${PRODUCT}","${INSTANCE_NAME}","${IMAGE_NAME}","${IMAGE_FLAVOR}","${SSH_KEY_NAME}"


### PR DESCRIPTION
This creates a job 'Satellite6-Upgrader' for Satellite upgrade automation CI in Jenkins.
Using this job anybody can run satellite upgrade on pre-installed image on openstack from Jenkins.

Pre-requisite to run this job:
1. ssh-key should be already added into openstack project before running this job. So that openstack can add this key into upgrade instance to ssh to that instance/system.
2. All required config files should be added in Openstack.

Parameters required to run this job:
1. PROJECT
2. OS
3. INSTNACE_NAME
4. IMAGE_NAME
5. IMAGE_FLAVOR
6. SSH_KEY_NAME

Thanks.