### PR TITLE
Improve standalone script

### DIFF
--- a/scripts/satellite6-standalone-automation.sh
+++ b/scripts/satellite6-standalone-automation.sh
@@ -22,7 +22,7 @@ sed -i "s/admin.password.*/admin.password=${FOREMAN_ADMIN_PASSWORD}/" robottelo.
 NOSETESTS="$(which nosetests) --logging-filter=nailgun,robottelo --with-xunit \
     --xunit-file=foreman-results.xml"
 
-if [ -n "${NOSE_OPTIONS}" ]; then
+if [ -n "${NOSE_OPTIONS:-}" ]; then
     ${NOSETESTS} ${NOSE_OPTIONS}
     exit 0
 fi


### PR DESCRIPTION
Avoid unset variable error for NOSE_OPTIONS since it may be unset in
case not specified as parameter.

Thanks to @Ichimonji10 for the bash-fu knowledge sharing.