### PR TITLE
Enable skipping downstream test cases only:

### DIFF
--- a/jobs/product-automation.yaml
+++ b/jobs/product-automation.yaml
@@ -104,6 +104,7 @@
         - satellite6-automation-wrappers
         - inject:
             properties-content: |
+                DISTRIBUTION={distribution}
                 ENDPOINT=smoke
                 PRODUCT={product}
     builders:
@@ -128,6 +129,7 @@
         - satellite6-automation-wrappers
         - inject:
             properties-content: |
+                DISTRIBUTION={distribution}
                 ENDPOINT=api
                 PRODUCT={product}
     builders:
@@ -153,6 +155,7 @@
         - satellite6-automation-wrappers
         - inject:
             properties-content: |
+                DISTRIBUTION={distribution}
                 ENDPOINT=cli
                 PRODUCT={product}
     builders:
@@ -178,6 +181,7 @@
         - satellite6-automation-wrappers
         - inject:
             properties-content: |
+                DISTRIBUTION={distribution}
                 ENDPOINT=ui
                 PRODUCT={product}
     builders:
@@ -208,6 +212,7 @@
         - satellite6-automation-wrappers
         - inject:
             properties-content: |
+                DISTRIBUTION={distribution}
                 ENDPOINT=rhai
                 PRODUCT={product}
     builders:

--- a/scripts/automation.sh
+++ b/scripts/automation.sh
@@ -24,4 +24,10 @@ sed -i "s/project.*/project=$PRODUCT/" robottelo.properties
 # Robottelo logging configuration
 sed -i "s/'\(robottelo\).log'/'\1-${ENDPOINT}.log'/" logging.conf
 
+# upstream = 1 for Distributions: UPSTREAM (default in robottelo.properties)
+# upstream = 0 for Distributions: DOWNSTREAM, CDN, BETA, ISO
+if [[ "$DISTRIBUTION" != *"UPSTREAM"* ]]; then
+   sed -i "s/upstream.*/upstream=0/" robottelo.properties
+fi
+
 make test-foreman-$ENDPOINT


### PR DESCRIPTION
Proposed process:
1. Update 'Verified in Upstream' in Bugzilla Whiteboard field when bug is verified in upstream
2. Skip downstream tests even though they are in closed status if Whiteboard field has the expected text