### PR TITLE
Added longrun job configuration

### DIFF
--- a/jobs/product-automation.yaml
+++ b/jobs/product-automation.yaml
@@ -217,6 +217,32 @@
                 PRODUCT={product}
     builders:
         - satellite6-automation-builders
+        - trigger-builds:
+            - project: '{product}-automation-{distribution}-{os}-longrun'
+              current-parameters: true
+    publishers:
+        - satellite6-automation-publishers
+
+- job-template:
+    name: '{product}-automation-{distribution}-{os}-longrun'
+    parameters:
+        - satellite6-automation-parameters
+    scm:
+        - git:
+            url: https://github.com/SatelliteQE/robottelo.git
+            branches:
+                - '{scm-branch}'
+            skip-tag: true
+    wrappers:
+        - satellite6-automation-wrappers
+        - inject:
+            properties-content: |
+                DISTRIBUTION={distribution}
+                ENDPOINT=longrun
+                PRODUCT={product}
+    builders:
+        - satellite6-automation-builders
+        - satellite6-automation-profiling-builder
     publishers:
         - satellite6-automation-publishers
 


### PR DESCRIPTION
For now, the longrun job is triggered at the very end - after completion of rhai tests.  This job will be moved up in future, if necessary.