### PR TITLE
Update the conditional trigger label

### DIFF
--- a/jobs/product-automation.yaml
+++ b/jobs/product-automation.yaml
@@ -190,7 +190,7 @@
         - conditional-step:
             condition-kind: regex-match
             regex: (cdn|downstream)
-            label: {distribution}
+            label: ${{ENV,var="DISTRIBUTION"}}
             steps:
                 - trigger-builds:
                     - project: '{product}-automation-{distribution}-{os}-rhai'


### PR DESCRIPTION
Check for the environment variable value of the distribution in order to
match using the regex for triggering the RHAI job.