### PR TITLE
Add longrun job to the project

### DIFF
--- a/jobs/product-automation.yaml
+++ b/jobs/product-automation.yaml
@@ -275,6 +275,7 @@
         - '{product}-automation-{distribution}-{os}-cli'
         - '{product}-automation-{distribution}-{os}-ui'
         - '{product}-automation-{distribution}-{os}-rhai'
+        - '{product}-automation-{distribution}-{os}-longrun'
 
 #==============================================================================
 # Jobs


### PR DESCRIPTION
This is needed in order to tell jenkins job builder that it should
include that template when generating the jobs.