### PR TITLE
Added support for providing CAPSULE and TOOLS URL for sat6-trigger.

### DIFF
--- a/jobs/product-automation.yaml
+++ b/jobs/product-automation.yaml
@@ -6,7 +6,17 @@
     parameters:
         - string:
             name: BASE_URL
-            description: Required for dowstream and iso distributions
+            description: Required for downstream and iso distributions
+        - string:
+            name: CAPSULE_URL
+            description: Required for downstream, iso, distributions for latest External Capsule setups. |
+                Not required in CDN distribution, this content should be enabled/synced from cdn.redhat.com using manifests. |
+                Leaving this blank picks the latest CAPSULE repo. Override if required.
+        - string:
+            name: TOOLS_URL
+            description: Required for downstream, iso, distributions for latest sattools client packages. |
+                Not required in CDN distribution, this content should be enabled/synced from cdn.redhat.com using manifests. |
+                Leaving this blank picks the latest SATTOOLS repo. Override if required.
         - choice:
             name: SELINUX_MODE
             choices:
@@ -289,17 +299,49 @@
             description: |
                 Leave it blank to install the latest stable.
         - string:
+            name: RHEL6_OS_CAPSULE_URL
+            description: |
+                Leave it blank to install the latest stable. Example: http://example.com/path/to/Satellite/Satellite-6.1.0-RHEL-6-20150311.1/compose/Capsule/x86_64/os
+        - string:
+            name: RHEL6_OS_TOOLS_URL
+            description: |
+                Leave it blank to install the latest stable. Example: http://example.com/path/to/Satellite/Satellite-6.1.0-RHEL-6-20150311.1/compose/sattools/x86_64/os
+        - string:
             name: RHEL7_OS_URL
             description: |
                 Leave it blank to install the latest stable.
+        - string:
+            name: RHEL7_OS_CAPSULE_URL
+            description: |
+                Leave it blank to install the latest stable. Example: http://example.com/path/to/Satellite/Satellite-6.1.0-RHEL-7-20150311.1/compose/Capsule/x86_64/os
+        - string:
+            name: RHEL7_OS_TOOLS_URL
+            description: |
+                Leave it blank to install the latest stable. Example: http://example.com/path/to/Satellite/Satellite-6.1.0-RHEL-7-20150311.1/compose/sattools/x86_64/os
         - string:
             name: RHEL6_ISO_URL
             description: |
                 Leave it blank to install the latest stable.
         - string:
+            name: RHEL6_ISO_CAPSULE_URL
+            description: |
+                Leave it blank to install the latest stable. Example: http://example.com/path/to/Satellite/Satellite-6.1.0-RHEL-6-20150311.1/compose/Capsule/x86_64/iso
+        - string:
+            name: RHEL6_ISO_TOOLS_URL
+            description: |
+                Leave it blank to install the latest stable. Example: http://example.com/path/to/Satellite/Satellite-6.1.0-RHEL-6-20150311.1/compose/sattools/x86_64/iso
+        - string:
             name: RHEL7_ISO_URL
             description: |
                 Leave it blank to install the latest stable.
+        - string:
+            name: RHEL7_ISO_CAPSULE_URL
+            description: |
+                Leave it blank to install the latest stable. Example: http://example.com/path/to/Satellite/Satellite-6.1.0-RHEL-7-20150311.1/compose/Capsule/x86_64/iso
+        - string:
+            name: RHEL7_ISO_TOOLS_URL
+            description: |
+                Leave it blank to install the latest stable. Example: http://example.com/path/to/Satellite/Satellite-6.1.0-RHEL-7-20150311.1/compose/sattools/x86_64/iso
         - choice:
             name: SELINUX_MODE
             choices:
@@ -320,31 +362,47 @@
             source ${SATELLITE6_REPOS_URLS}
 
             echo "RHEL6_OS_URL=${RHEL6_OS_URL:-${SATELLITE6_RHEL6_OS}}" > properties.txt
+            echo "RHEL6_OS_CAPSULE_URL=${RHEL6_OS_CAPSULE_URL:-${CAPSULE_RHEL6_OS}}" > properties.txt
+            echo "RHEL6_OS_TOOLS_URL=${RHEL6_OS_TOOLS_URL:-${TOOLS_RHEL6_OS}}" > properties.txt
             echo "RHEL7_OS_URL=${RHEL7_OS_URL:-${SATELLITE6_RHEL7_OS}}" >> properties.txt
+            echo "RHEL7_OS_CAPSULE_URL=${RHEL7_OS_CAPSULE_URL:-${CAPSULE_RHEL7_OS}}" >> properties.txt
+            echo "RHEL7_OS_TOOLS_URL=${RHEL7_OS_TOOLS_URL:-${TOOLS_RHEL7_OS}}" >> properties.txt
             echo "RHEL6_ISO_URL=${RHEL6_ISO_URL:-${SATELLITE6_RHEL6_ISO}}" >> properties.txt
+            echo "RHEL6_ISO_CAPSULE_URL=${RHEL6_ISO_CAPSULE_URL:-${CAPSULE_RHEL6_ISO}}" > properties.txt
+            echo "RHEL6_ISO_TOOLS_URL=${RHEL6_ISO_TOOLS_URL:-${TOOLS_RHEL6_ISO}}" > properties.txt
             echo "RHEL7_ISO_URL=${RHEL7_ISO_URL:-${SATELLITE6_RHEL7_ISO}}" >> properties.txt
+            echo "RHEL7_ISO_CAPSULE_URL=${RHEL7_ISO_CAPSULE_URL:-${CAPSULE_RHEL7_ISO}}" > properties.txt
+            echo "RHEL7_ISO_TOOLS_URL=${RHEL7_ISO_TOOLS_URL:-${TOOLS_RHEL7_ISO}}" > properties.txt
         - inject:
             properties-file: properties.txt
         - trigger-builds:
             - project: satellite6-provisioning-downstream-rhel67
               predefined-parameters: |
                 BASE_URL=${RHEL6_OS_URL}
+                CAPSULE_URL=${RHEL6_OS_CAPSULE_URL}
+                TOOLS_URL=${RHEL6_OS_TOOLS_URL}
                 SELINUX_MODE=${SELINUX_MODE}
         - trigger-builds:
             - project: satellite6-provisioning-downstream-rhel71
               predefined-parameters: |
                 BASE_URL=${RHEL7_OS_URL}
+                CAPSULE_URL=${RHEL7_OS_CAPSULE_URL}
+                TOOLS_URL=${RHEL7_OS_TOOLS_URL}
                 SELINUX_MODE=${SELINUX_MODE}
         - trigger-builds:
             - project: satellite6-provisioning-iso-rhel67
               predefined-parameters: |
                 BASE_URL=${RHEL6_ISO_URL}
+                CAPSULE_URL=${RHEL6_ISO_CAPSULE_URL}
+                TOOLS_URL=${RHEL6_ISO_TOOLS_URL}
                 SELINUX_MODE=${SELINUX_MODE}
                 CHECK_GPG_SIGNATURES=${CHECK_GPG_SIGNATURES}
         - trigger-builds:
             - project: satellite6-provisioning-iso-rhel71
               predefined-parameters: |
                 BASE_URL=${RHEL7_ISO_URL}
+                CAPSULE_URL=${RHEL7_ISO_CAPSULE_URL}
+                TOOLS_URL=${RHEL7_ISO_TOOLS_URL}
                 SELINUX_MODE=${SELINUX_MODE}
                 CHECK_GPG_SIGNATURES=${CHECK_GPG_SIGNATURES}
 
@@ -357,18 +415,38 @@
             description: |
                 End with the arch. Example: http://example.com/path/to/Satellite/Satellite-6.1.0-RHEL-6-20150311.1/compose/Satellite/x86_64
         - string:
+            name: RHEL6_CAPSULE_URL
+            description: |
+                End with the arch. Example: http://example.com/path/to/Satellite/Satellite-6.1.0-RHEL-6-20150311.1/compose/Capsule/x86_64
+        - string:
+            name: RHEL6_TOOLS_URL
+            description: |
+                End with the arch. Example: http://example.com/path/to/Satellite/Satellite-6.1.0-RHEL-6-20150311.1/compose/sattools/x86_64
+        - string:
             name: RHEL7_BASE_URL
             description: |
                 End with the arch. Example: http://example.com/path/to/Satellite/Satellite-6.1.0-RHEL-7-20150311.1/compose/Satellite/x86_64
+        - string:
+            name: RHEL7_CAPSULE_URL
+            description: |
+                End with the arch. Example: http://example.com/path/to/Satellite/Satellite-6.1.0-RHEL-7-20150311.1/compose/Capsule/x86_64
+        - string:
+            name: RHEL7_TOOLS_URL
+            description: |
+                End with the arch. Example: http://example.com/path/to/Satellite/Satellite-6.1.0-RHEL-7-20150311.1/compose/sattools/x86_64
     builders:
         - trigger-builds:
             - project: satellite6-provisioning-zstream-rhel66
               predefined-parameters:
                 BASE_URL=${RHEL6_BASE_URL}/os
+                CAPSULE_URL=${RHEL6_CAPSULE_URL}/os
+                TOOLS_URL=${RHEL6_TOOLS_URL}/os
         - trigger-builds:
             - project: satellite6-provisioning-zstream-rhel70
               predefined-parameters:
                 BASE_URL=${RHEL7_BASE_URL}/os
+                CAPSULE_URL=${RHEL7_CAPSULE_URL}/os
+                TOOLS_URL=${RHEL7_TOOLS_URL}/os
 
 - job:
     name: satellite6-upstream-trigger

--- a/scripts/automation.sh
+++ b/scripts/automation.sh
@@ -30,4 +30,15 @@ if [[ "$DISTRIBUTION" != *"UPSTREAM"* ]]; then
    sed -i "s/upstream.*/upstream=0/" robottelo.properties
 fi
 
+
+# cdn = 1 for Distributions: CDN (default in robottelo.properties)
+# cdn = 0 for Distributions: DOWNSTREAM, BETA, ISO, ZSTREAM
+# Sync content and use the below repos only when DISTRIBUTION is not CDN
+if [[ "$DISTRIBUTION" != *"CDN"* ]]; then
+   # The below cdn flag is required by automation to flip between RH & custom syncs.
+   sed -i "s/cdn.*/cdn=0/" robottelo.properties
+   sed -i "s/clients\.capsule_repo.*/clients\.capsule_repo=$CAPSULE_URL/" robottelo.properties
+   sed -i "s/clients\.sattools_repo.*/clients\.sattools_repo=$TOOLS_URL/" robottelo.properties
+fi
+
 make test-foreman-$ENDPOINT

--- a/scripts/satellite6_upgrader.sh
+++ b/scripts/satellite6_upgrader.sh
@@ -14,5 +14,7 @@ source "${SUBSCRIPTION_CONFIG}"
 
 # Export required Environment variables
 export BASE_URL="${SATELLITE6_OS_REPO}"
+export CAPSULE_URL="${CAPSULE_OS_REPO}"
+export TOOLS_URL="${TOOLS_OS_REPO}"
 
 fab -i ~/.ssh/id_hudson_dsa -u root product_upgrade:"${PRODUCT}","${INSTANCE_NAME}","${IMAGE_NAME}","${IMAGE_FLAVOR}","${SSH_KEY_NAME}"


### PR DESCRIPTION
*) This is required for Non-CDN Jobs.
*) It's configured to pick up default values if not provided.
*) Robottelo code should flip between CDN and these URLS
   depending on the cdn flag in robottelo.properties file.
*) Also updated the satellite6_upgrader.sh with these URLS.