### PR TITLE
Fixed the repo variables for capsule and sattools

### DIFF
--- a/jobs/product-automation.yaml
+++ b/jobs/product-automation.yaml
@@ -84,6 +84,7 @@
                 source $INSTALL_CONFIG
                 source $PROVISIONING_CONFIG
                 source $PROXY_CONFIG
+                export $CAPSULE_URL
                 if [ "$STAGE_TEST" = 'false' ]; then
                     source $SUBSCRIPTION_CONFIG
                 else
@@ -96,7 +97,6 @@
                 fab -H "root@$PROVISIONING_HOST" -i ~/.ssh/id_hudson_dsa "product_install:$DISTRIBUTION,create_vm=true,sat_cdn_version=$SATELLITE_VERSION,test_in_stage=$STAGE_TEST"
                 # Write a properties file to allow passing variables to other build steps
                 echo "SERVER_HOSTNAME=$TARGET_IMAGE.$VM_DOMAIN" > build_env.properties
-                echo "CAPSULE_REPO=$CAPSULE_URL" >> build_env.properties
                 echo "TOOLS_REPO=$TOOLS_URL" >> build_env.properties
         - inject:
             properties-file: build_env.properties
@@ -104,8 +104,7 @@
             - project: '{product}-smoke-{distribution}-{os}'
               predefined-parameters: |
                 SERVER_HOSTNAME=$SERVER_HOSTNAME
-                CAPSULE_REPO=$CAPSULE_URL
-                TOOLS_REPO=$TOOLS_URL
+                TOOLS_REPO=$TOOLS_REPO
 
 - job-template:
     name: '{product}-smoke-{distribution}-{os}'

--- a/scripts/automation.sh
+++ b/scripts/automation.sh
@@ -37,7 +37,8 @@ fi
 if [[ "$DISTRIBUTION" != *"CDN"* ]]; then
    # The below cdn flag is required by automation to flip between RH & custom syncs.
    sed -i "s/cdn.*/cdn=0/" robottelo.properties
-   sed -i "s/clients\.sattools_repo.*/clients\.sattools_repo=$TOOLS_REPO/" robottelo.properties
+   # Using # intentionally as TOOLS_REPO brings in URL which will have '/'.
+   sed -i "s#sattools_repo.*#sattools_repo=$TOOLS_REPO#" robottelo.properties
 fi
 
 make test-foreman-$ENDPOINT


### PR DESCRIPTION
*) As re-triggering the jobs looses the TOOLS_REPO value
*) Also as TOOLS_REPO brings in a http url, using '#' instead of '/'