### PR TITLE
Added a job to build Satellite 6 Foreman in Mock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 jenkins_jobs.ini
 foreman-infra
+*.pyc

--- a/jobs/satellite6-builder.yaml
+++ b/jobs/satellite6-builder.yaml
@@ -1,0 +1,17 @@
+- job:
+    name: 'satellite6-builder-foreman'
+    display-name: 'Downstream package Builder for foreman'
+    description: |
+        <p>Job to build the foreman downstream packages</p>
+        <p>This job requires a connection to Brew so it can only work inside the
+        Red Hat network</p>
+    node: builders
+    scm:
+        - foreman_gitlab_checkout
+        - robotello-ci_github
+    builders:
+        - shell:
+            !include-raw satellite6-builder.sh
+    publishers:
+        - archive:
+            artifacts: build_results/*

--- a/jobs/scm/foreman_gitlab_checkout.yaml
+++ b/jobs/scm/foreman_gitlab_checkout.yaml
@@ -1,0 +1,10 @@
+- scm:
+    name: foreman_gitlab_checkout
+    scm:
+        - git:
+            url: 'https://$GIT_HOSTNAME/$GIT_ORGANIZATION/foreman.git'
+            branches:
+                - origin/${gitlabSourceBranch}
+            skip-tag: true
+            wipe-workspace: true
+            basedir: 'foreman'

--- a/jobs/scm/robotello-ci_github.yaml
+++ b/jobs/scm/robotello-ci_github.yaml
@@ -1,0 +1,10 @@
+- scm:
+    name: robotello-ci_github
+    scm:
+        - git:
+            url: 'https://github.com/SatelliteQE/robottelo-ci.git'
+            branches:
+                - master
+            skip-tag: true
+            wipe-workspace: true
+            basedir: 'robotello-ci'

--- a/lib/python/custom_mock_chroot.py
+++ b/lib/python/custom_mock_chroot.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+"""custom_mock_chroot.py - Manage mock(1) chroots with custom configuration
+"""
+import os
+from tempfile import mkstemp
+from pprint import pformat
+
+from mock_chroot import MockChroot
+from deep_update import deep_update
+
+__all__ = ['CustomMockChroot']
+
+
+class CustomMockChroot(MockChroot):
+    """Thin Python wrapper around mock(1) with custom configuraion
+    """
+    def __init__(
+        self,
+        config='',
+        config_opts=None,
+        extend=None
+    ):
+        """Create a custom mock(1) chroot
+
+        :param str config: The configuration for the chroot as a string
+        :param dict config_opts: The Mock configuration as a python structure
+        :param CustomMockChroot extend: An object with existing configuration to
+                                        extend, this option is mutually
+                                        exclusive with 'config'
+
+        At least one way to specify configuration must be used, if more then one
+        is used, they will be merged together
+        """
+        if extend:
+            if config:
+                raise RuntimeError(
+                    "'config' and 'extend' options are mutually exclusive"
+                )
+            self._config = extend._config
+            self._config_opts = extend._config_opts or {}
+            if config_opts:
+                deep_update(self._config_opts, config_opts)
+        else:
+            self._config = config
+            self._config_opts = config_opts or {}
+        (fd, self._cfg_name) = mkstemp(suffix='.cfg')
+        try:
+            final_config = self._build_mock_config(
+                config=self._config,
+                config_opts=self._config_opts
+            )
+            os.write(fd, final_config)
+        finally:
+            os.close(fd)
+        super(CustomMockChroot, self).__init__(self._cfg_name)
+
+    def __del__(self):
+        try:
+            os.remove(self._cfg_name)
+        except AttributeError:
+            pass
+
+    @staticmethod
+    def _build_mock_config(config='', config_opts=None):
+        """Build the contents of a Mock configuration file
+
+        :param str config: The configuration for the chroot as a string
+        :param dict config_opts: The Mock configuration as a python structure
+
+        At least one way to specify configuration must be used, if more then one
+        is used, they will be merged together
+
+        :returns: The Mock configuration string
+        :rvalue: str
+        """
+        if not (config or config_opts):
+            raise RuntimeError('No useful mock configuration specified')
+        if config:
+            final_config = [config]
+        else:
+            final_config = []
+        if config_opts:
+            final_config.append('extra_config = ' + pformat(config_opts))
+            with open(
+                os.path.join(os.path.dirname(__file__), 'deep_update.py')
+            ) as dufile:
+                # Need to wrap the deep_update module code with a function to
+                # have a scope to define its global symbols in
+                final_config.append(
+                    'def _deep_update(config_opts, extra_config):'
+                )
+                final_config.extend((
+                    ' ' * 4 + line.rstrip()
+                    for line in dufile
+                    if line and not line.startswith('#')
+                ))
+            final_config.append('\n    deep_update(config_opts, extra_config)')
+            final_config.append('\n_deep_update(config_opts, extra_config)')
+        return '\n'.join(final_config)

--- a/lib/python/deep_update.py
+++ b/lib/python/deep_update.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""deep_update.py - Function for performing deep updates to data structures
+"""
+from collections import MutableMapping, MutableSequence
+
+
+def deep_update(original, updates):
+    """Update the original data structure with given data
+
+    :param iterable original: The original data structure (Typially a list or a
+                              dict)
+    :param iterable updates: The data structure containnig updates
+    :rtype: bool
+    :returns: True if the original could be updated (E.g. it is a list or a
+              dict)
+    """
+    if isinstance(original, MutableMapping):
+        try:
+            updates_iter = updates.iteritems()
+        except AttributeError:
+            updates_iter = iter(updates)
+        for key, value in updates_iter:
+            if key in original:
+                if not deep_update(original[key], value):
+                    original[key] = value
+            else:
+                original[key] = value
+        return True
+    elif isinstance(original, MutableSequence):
+        original.extend(updates)
+        return True
+    else:
+        return False

--- a/lib/python/koji_mock.py
+++ b/lib/python/koji_mock.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+"""koji_mock.py - Wrapper around Koji-managed mock chroots
+"""
+from subprocess import check_output
+
+from custom_mock_chroot import CustomMockChroot
+
+__all__ = ['KojiMock']
+
+
+class KojiMock(CustomMockChroot):
+    """Wrapper around Koji-managed mock chroots
+    """
+    def __init__(
+        self, tag=None, target=None, arch='x86_64', koji_profile='brew'
+    ):
+        """Create a koji-based mock(1) chroot
+
+        :param str tag: The Koji tag to pull configuration from
+        :param str target: The Koji build target tag to pull configuration from
+        :param str arch: The Koji build architecture
+        :param str koji_profile: The koji configuration profile to use
+
+        One and only one of 'tag' or 'target' must be specified
+        """
+        config = self.koji_mock_config(
+            tag=tag,
+            target=target,
+            arch=arch,
+            koji_profile=koji_profile
+        )
+        super(KojiMock, self).__init__(config=config)
+
+    @classmethod
+    def koji_mock_config(
+        cls, tag=None, target=None, arch='x86_64', koji_profile='brew'
+    ):
+        """Get the Mock configuration for the given koji tag/target and arch
+
+        :param str tag: The Koji tag to pull configuration from
+        :param str target: The Koji build target tag to pull configuration from
+        :param str arch: The Koji build architecture
+        :param str koji_profile: The koji configuration profile to use
+
+        One and only one of 'tag' or 'target' must be specified
+
+        :rtype: str
+        :returns: The Mock configuration as string
+        """
+        koji_cmd = [
+            cls.koji_exe(),
+            '--profile', koji_profile,
+            'mock_config',
+            '--arch', arch,
+        ]
+        if tag and target:
+            raise RuntimeError(
+                "'tag' and 'target' arguments are mutually exclusive"
+            )
+        elif tag:
+            koji_cmd.extend(('--tag', tag))
+        elif target:
+            koji_cmd.extend(('--target', target))
+        else:
+            raise RuntimeError(
+                "one of 'tag' and 'target' arguments must be specified"
+            )
+        output = check_output(koji_cmd)
+        return output
+
+    @classmethod
+    def koji_exe(cls):
+        # We use the koji executable rather then the koji Python library because
+        # the library doesn't contain the configuration file parsing
+        # functionality
+        return '/usr/bin/koji'
+
+if __name__ == '__main__':
+    print KojiMock.koji_mock_config(tag='rhevm-3.5-rhel-6-mead-build')

--- a/lib/python/mock_brew.py
+++ b/lib/python/mock_brew.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# mock_brew.py - Emulate brew using mock
+#
+import sys
+import argparse
+
+from koji_mock import KojiMock
+
+
+def main():
+    brew_tag = 'ruby193-satellite-6.1.0-rhel-7-build'
+    args = parse_args()
+
+    mock = KojiMock(tag=brew_tag)
+    out = mock.rebuild(
+        src_rpm=args.srpm,
+        define="scl ruby193",
+        resultdir=args.resultdir,
+    )
+    print out
+
+
+def parse_args():
+    """Parse arguments passed to this program
+
+    :returns: The parsed arguments
+    :rtype: argparse.Namespace
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('srpm', help='Path to the .src.rpm file to buid')
+    parser.add_argument('--resultdir', help='Where to place build results')
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    main()

--- a/lib/python/mock_chroot.py
+++ b/lib/python/mock_chroot.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+"""mock_chroot.py - Thin Python wrapper around mock(1)
+"""
+from subprocess import check_output
+from collections import Iterable
+
+__all__ = ['MockChroot']
+
+
+class MockChroot(object):
+    """Thin Python wrapper around mock(1)
+    """
+    def __init__(self, root='/etc/mock/default.cfg'):
+        """Create a mock(1) chroot
+        :param str root: The name or path for the mock configuration file to use
+        """
+        self._root = root
+
+    def chroot(self, *cmd):
+        """Run a non-interactive command in mock
+
+        All positional arguments are passes as the command to run and its
+        argumens
+        This method will behave in a similliar manner to subprocess.check_output
+        yeilding CalledProcessError on command failure
+
+        :returns: the command output as string
+        :rtype: str
+        """
+        mock_cmd = self._mock_cmd('--chroot', '--', *cmd)
+        output = check_output(mock_cmd)
+        return output
+
+    def clean(self):
+        """Clean the mock chroot
+        """
+        mock_cmd = self._mock_cmd('--clean')
+        check_output(mock_cmd)
+
+    def rebuild(self, src_rpm, define=None, resultdir=None):
+        """Build a package from .src.rpm in Mock
+
+        :param str src_rpm: The path to the .src.rpm file to build
+        :param list define: An optional list of defines for the build process
+        :param str resultdir: Override where the build results get placed
+
+        :returns: the command output as string
+        :rtype: str
+        """
+        options = ()
+        if define:
+            if isinstance(define, basestring):
+                options += ('--define', define)
+            elif isinstance(define, Iterable):
+                options += reduce(lambda l, x: l + ('--define', x), define, ())
+            else:
+                raise TypeError("given 'define' is not a list or a string")
+        if resultdir:
+            options += ('--resultdir', resultdir)
+        mock_cmd = self._mock_cmd('--rebuild', src_rpm, *options)
+        output = check_output(mock_cmd)
+        return output
+
+    def _mock_cmd(self, *more_args):
+        cmd = [self.mock_exe(), '--root={}'.format(self._root)]
+        cmd.extend(more_args)
+        return tuple(cmd)
+
+    @classmethod
+    def mock_exe(cls):
+        return '/usr/bin/mock'

--- a/scripts/satellite6-builder.sh
+++ b/scripts/satellite6-builder.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -ex
+# satellite6-builder.sh - Build Satellite 6 packages
+#
+#   This script should be run from the root of the package's git repo
+#
+# Requirements:
+# - tito
+# - koji
+# - brewkoji
+# - mock (Please ensure the user running the script is in the 'mock' group)
+#
+#TODO: Set a parameter for this
+DIST='.el7'
+OUTPUTDIR='build_results'
+PYLIBSPATH="$(dirname "$0")/../lib/python"
+
+if [[ -n "$WORKSPACE" ]]; then
+    # if $WORKSPACE is set assume we are in Jenkins
+    OUTPUTDIR="$WORKSPACE/build_results"
+    PYLIBSPATH="$WORKSPACE/robotello-ci/lib/python"
+    #TODO: parameterize this:
+    PROJECT_PATH="foreman"
+    cd "$PROJECT_PATH"
+fi
+
+mkdir -p "$OUTPUTDIR"
+SRC_RPM="$(
+    tito build \
+        --offline \
+        --srpm \
+        --test \
+        --dist="${DIST}" \
+        --scl=ruby193 \
+        --output="$OUTPUTDIR" \
+    | sed -nre 's/^Wrote: (.*\.src\.rpm)$/\1/p'
+)"
+
+echo Tito built: "$SRC_RPM"
+
+python "$PYLIBSPATH/mock_brew.py" \
+    --resultdir="$OUTPUTDIR" \
+    "$SRC_RPM"


### PR DESCRIPTION
- Build hard-coded to EL7/x86_64 for now
- Build results are saved as Jenkins build artifacts
- Mock is configured with a Koji tag instead of a build target because of a bug in the Koji executable (will be worked-around)

Note: Also made Git ignore Python intermediate files