### PR TITLE
Require head of master for jenkins job builder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-jenkins-job-builder
+git+https://github.com/openstack-infra/jenkins-job-builder.git#egg=jenkins-job-builder
 requests


### PR DESCRIPTION
This version is needed to allow gitlab configurations for merge
requests.