### PR TITLE
Setup Katello configuration file before running tests

### DIFF
--- a/jobs/satellite6-unit-test-katello.yaml
+++ b/jobs/satellite6-unit-test-katello.yaml
@@ -8,6 +8,7 @@
       - katello_gitlab
       - foreman_plugin_gitlab
     builders:
+      - shell: !include-raw scripts/setup_katello_config.sh
       - test_katello
     publishers:
       - gemset_cleanup

--- a/scripts/setup_katello_config.sh
+++ b/scripts/setup_katello_config.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -xe
+
+cd plugin
+cp script/ci/katello.yml config/


### PR DESCRIPTION
Upstream Katello has changed how configuration is handled, so we
need this extra script included to setup properly.