### PR TITLE
setting discovery_iso in robottelo properties via env variable

### DIFF
--- a/scripts/automation.sh
+++ b/scripts/automation.sh
@@ -17,6 +17,9 @@ if [[ "${DISTRIBUTION}" != *"upstream"* ]]; then
        sed -i "s/^# netmask.*/netmask=${NETMASK}/" robottelo.properties
        sed -i "s/^# gateway.*/gateway=${GATEWAY}/" robottelo.properties
        sed -i "s/^# bridge.*/bridge=${BRIDGE}/" robottelo.properties
+       # To set the discovery ISO name in properties file
+       sed -i "s/^# \[discovery\].*/[discovery]/" robottelo.properties
+       sed -i "s/^# discovery_iso.*/discovery_iso=${DISCOVERY_ISO}/" robottelo.properties
     fi
 fi
 


### PR DESCRIPTION
I'm exporting `DISCOVERY_ISO` via provisioning variables in jenkins and updated the robottelo properties file in jenkins. 
Assuming the change defined in this PR is sufficient to set the correct value of variable in  robottelo properties. 

Please review and suggest if any changes are required