### PR TITLE
Added discovery_iso param to automation parameter

### DIFF
--- a/jobs/parameters/satellite6_automation_parameters.yaml
+++ b/jobs/parameters/satellite6_automation_parameters.yaml
@@ -20,3 +20,6 @@
             description: 'The bridge of the vlan network, for the above Server Hostname.'
         - string:
             name: BUILD_LABEL
+        - string:
+            name: DISCOVERY_ISO
+            description: 'The discovery ISO name.'

--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -105,6 +105,7 @@
                 echo "NETMASK=$NETMASK" >> build_env.properties
                 echo "GATEWAY=$GATEWAY" >> build_env.properties
                 echo "BRIDGE=$BRIDGE" >> build_env.properties
+                echo "DISCOVERY_ISO=$DISCOVERY_ISO" >> build_env.properties
         - inject:
             properties-file: build_env.properties
         - trigger-builds:
@@ -117,6 +118,7 @@
                 GATEWAY=$GATEWAY
                 BRIDGE=$BRIDGE
                 BUILD_LABEL=$BUILD_LABEL
+                DISCOVERY_ISO=$DISCOVERY_ISO
 
 - job-template:
     name: 'satellite6-automation-{distribution}-{os}-tier1'


### PR DESCRIPTION
discovery tests are failing due to below:
```
LibvirtGuestError: Failed to run virt-install: ERROR    Error validating install location: Checking installer location failed: Could not find media '/var/lib/libvirt/images/None
```
Looks like 'None` is being passed instead of discovery iso name. It means robottelo.properties file is not getting set with correct iso name. Hope this change should fix the issue.