### PR TITLE
Archive foreman-debug on Satellite 6 provisioning

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -99,6 +99,7 @@
                 fi
 
                 fab -H "root@$PROVISIONING_HOST" "product_install:$DISTRIBUTION,create_vm=true,sat_cdn_version=$SATELLITE_VERSION,test_in_stage=$STAGE_TEST"
+
                 # Write a properties file to allow passing variables to other build steps
                 echo "SERVER_HOSTNAME=$TARGET_IMAGE.$VM_DOMAIN" > build_env.properties
                 echo "TOOLS_REPO=$TOOLS_URL" >> build_env.properties
@@ -120,6 +121,15 @@
                 BRIDGE=$BRIDGE
                 BUILD_LABEL=$BUILD_LABEL
                 DISCOVERY_ISO=$DISCOVERY_ISO
+    publishers:
+        - postbuildscript:
+            builders:
+                - shell:
+                    !include-raw-escape: satellite6-automation-foreman-debug.sh
+            script-only-if-succeeded: false
+            script-only-if-failed: true
+        - archive:
+            artifacts: 'foreman-debug.tar.xz'
 
 - job-template:
     name: 'satellite6-automation-{distribution}-{os}-tier1'

--- a/scripts/satellite6-automation-foreman-debug.sh
+++ b/scripts/satellite6-automation-foreman-debug.sh
@@ -1,0 +1,10 @@
+# Grab log files
+rm -rf foreman-debug.tar.xz
+
+# Disable error checking, for more information check the related issue
+# http://projects.theforeman.org/issues/13442
+set +e
+ssh root@${PROVISIONING_HOST} foreman-debug -g -q -d ~/foreman-debug
+set -e
+
+scp -r root@${PROVISIONING_HOST}:~/foreman-debug/foreman-debug.tar.xz .


### PR DESCRIPTION
Generate a foreman-debug and archive it as an artifact on Satellite 6 provisioning runs that failed.

Close #47 