### PR TITLE
Add job to generate sources and upload them to a server

### DIFF
--- a/jobs/builders/generate_source.yaml
+++ b/jobs/builders/generate_source.yaml
@@ -1,0 +1,5 @@
+- builder:
+    name: generate_source
+    builders:
+        - shell: !include-raw scripts/generate_source.rb
+

--- a/jobs/satellite6-generate-source.yaml
+++ b/jobs/satellite6-generate-source.yaml
@@ -1,0 +1,25 @@
+- job:
+    name: satellite6-generate-source
+    logrotate:
+      daysToKeep: -1
+      numToKeep: 32
+    node: sesame
+    parameters:
+      - string:
+          name: repository
+          description: "Repository to build a source tarball or gem for"
+      - string:
+          name: ref
+          description: "Branch or tag to build source for"
+    # Can switch to SCM if git source is using proper certificates or a self-signed certificate
+    # with CA
+    #scm:
+    #  - git:
+    #      wipe-workspace: true
+    #      skip-tag: true
+    #      refspec: '${ref}'
+    #      remotes:
+    #        - origin:
+    #            url: 'https://$GIT_HOSTNAME/$GIT_ORGANIZATION/${repository}.git'
+    builders:
+      - generate_source

--- a/scripts/generate_source.rb
+++ b/scripts/generate_source.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+def gemspec?
+  !Dir.glob('*.gemspec').empty?
+end
+
+system("git -c http.sslVerify=false clone https://#{ENV['GIT_HOSTNAME']}/#{ENV['GIT_ORGANIZATION']}/#{ENV['repository']}.git")
+
+Dir.chdir(ENV['repository']) do
+  system("git -c http.sslVerify=false fetch origin")
+  system("git checkout #{ENV['ref']}")
+
+  if gemspec?
+    system("gem build *.gemspec")
+    artifact = "#{ENV['repository']}-*.gem"
+  else
+    artifact = "#{ENV['repository']}-#{ENV['ref']}.tar.bz2"
+    system("git archive | bzip2 -9 > #{artifact}")
+  end
+
+  system("scp -i ~/.ssh/id_hudson_dsa #{artifact} jenkins@#{ENV['SOURCE_FILE_HOST']}:/var/www/html/pub/sources/6.2")
+end
+
+system("rm -rf #{ENV['repository']}")


### PR DESCRIPTION
The intent of this job is to, for a given repository and branch or tag, generate a gem or tarball as a source and then upload it to a server that is storing sources statically. This is so that the sources are available when building via git annex.