### PR TITLE
Allow job to also run tests for main repository branch

### DIFF
--- a/jobs/builders/merge_request_builder.yaml
+++ b/jobs/builders/merge_request_builder.yaml
@@ -1,0 +1,5 @@
+- builder:
+    name: merge_request
+    builders:
+        - shell: !include-raw scripts/merge_request.sh
+

--- a/jobs/parameters/merge_request.yaml
+++ b/jobs/parameters/merge_request.yaml
@@ -2,10 +2,6 @@
     name: merge_request
     parameters:
       - string:
-          name: gitlabSourceRepoURL
-          default: 
-          description: 'Source repository that a merge request is coming from'
-      - string:
           name: gitlabSourceRepoName
           default: 
           description: 'Source repository name (e.g. ehelms/foreman)'

--- a/jobs/satellite6-unit-test-foreman-discovery.yaml
+++ b/jobs/satellite6-unit-test-foreman-discovery.yaml
@@ -8,6 +8,7 @@
       - foreman_discovery_gitlab
       - foreman_plugin_gitlab
     builders:
+      - merge_request
       - test_plugin
     publishers:
       - gemset_cleanup

--- a/jobs/satellite6-unit-test-foreman-docker.yaml
+++ b/jobs/satellite6-unit-test-foreman-docker.yaml
@@ -8,6 +8,7 @@
       - foreman_docker_gitlab
       - foreman_plugin_gitlab
     builders:
+      - merge_request
       - test_plugin
     publishers:
       - gemset_cleanup

--- a/jobs/satellite6-unit-test-foreman-openscap.yaml
+++ b/jobs/satellite6-unit-test-foreman-openscap.yaml
@@ -8,6 +8,7 @@
       - foreman_openscap_gitlab
       - foreman_plugin_gitlab
     builders:
+      - merge_request
       - test_plugin
     publishers:
       - gemset_cleanup

--- a/jobs/satellite6-unit-test-foreman.yaml
+++ b/jobs/satellite6-unit-test-foreman.yaml
@@ -7,6 +7,7 @@
     scm:
       - foreman_gitlab
     builders:
+      - merge_request
       - test_develop
     publishers:
       - gemset_cleanup

--- a/jobs/satellite6-unit-test-katello.yaml
+++ b/jobs/satellite6-unit-test-katello.yaml
@@ -8,6 +8,7 @@
       - katello_gitlab
       - foreman_plugin_gitlab
     builders:
+      - merge_request
       - shell: !include-raw scripts/setup_katello_config.sh
       - test_katello
     publishers:

--- a/jobs/satellite6-unit-test-smart-proxy.yaml
+++ b/jobs/satellite6-unit-test-smart-proxy.yaml
@@ -30,6 +30,7 @@
     execution-strategy:
       combination-filter: '!( (ruby ==~ /(1\.9|2).*/ && puppet ==~ /2\.6.*/) || (ruby ==~ /2.*/ && puppet ==~ /(2|3\.[01]).*/) || (ruby ==~ /2\.[^0]/ && puppet ==~ /(2|3\.[0-4]).*/) || (ruby ==~ /2\.2.*/ && puppet ==~ /(2|3).*/) || (ruby ==~ /1\.(8|9\.2).*/ && puppet ==~ /4\..*/) )'
     builders:
+      - merge_request
       - test_proxy
     publishers:
       - gemset_cleanup

--- a/jobs/scm/foreman_discovery_gitlab.yaml
+++ b/jobs/scm/foreman_discovery_gitlab.yaml
@@ -5,14 +5,8 @@
           wipe-workspace: true
           skip-tag: true
           basedir: 'plugin'
-          merge:
-            remote: origin
-            branch: ${gitlabTargetBranch}
-            fast-forward-mode: NO_FF
           branches:
-            - ${gitlabSourceRepoName}/${gitlabSourceBranch}
+            - ${gitlabTargetBranch}
           remotes:
             - origin:
                 url: 'https://$GIT_HOSTNAME/$GIT_ORGANIZATION/foreman_discovery.git'
-            - ${gitlabSourceRepoName}:
-                url: 'https://$GIT_HOSTNAME/${gitlabSourceRepoName}.git'

--- a/jobs/scm/foreman_docker_gitlab.yaml
+++ b/jobs/scm/foreman_docker_gitlab.yaml
@@ -5,14 +5,8 @@
           wipe-workspace: true
           skip-tag: true
           basedir: 'plugin'
-          merge:
-            remote: origin
-            branch: ${gitlabTargetBranch}
-            fast-forward-mode: NO_FF
           branches:
-            - ${gitlabSourceRepoName}/${gitlabSourceBranch}
+            - ${gitlabTargetBranch}
           remotes:
             - origin:
                 url: 'https://$GIT_HOSTNAME/$GIT_ORGANIZATION/foreman-docker.git'
-            - ${gitlabSourceRepoName}:
-                url: 'https://$GIT_HOSTNAME/${gitlabSourceRepoName}.git'

--- a/jobs/scm/foreman_gitlab.yaml
+++ b/jobs/scm/foreman_gitlab.yaml
@@ -4,14 +4,8 @@
       - git:
           wipe-workspace: true
           skip-tag: true
-          merge:
-            remote: origin
-            branch: ${gitlabTargetBranch}
-            fast-forward-mode: NO_FF
           branches:
-            - ${gitlabSourceRepoName}/${gitlabSourceBranch}
+            - ${gitlabTargetBranch}
           remotes:
             - origin:
                 url: 'https://$GIT_HOSTNAME/$GIT_ORGANIZATION/foreman.git'
-            - ${gitlabSourceRepoName}:
-                url: 'https://$GIT_HOSTNAME/${gitlabSourceRepoName}.git'

--- a/jobs/scm/foreman_openscap_gitlab.yaml
+++ b/jobs/scm/foreman_openscap_gitlab.yaml
@@ -5,14 +5,8 @@
           wipe-workspace: true
           skip-tag: true
           basedir: 'plugin'
-          merge:
-            remote: origin
-            branch: ${gitlabTargetBranch}
-            fast-forward-mode: NO_FF
           branches:
-            - ${gitlabSourceRepoName}/${gitlabSourceBranch}
+            - ${gitlabTargetBranch}
           remotes:
             - origin:
                 url: 'https://$GIT_HOSTNAME/$GIT_ORGANIZATION/foreman_openscap.git'
-            - ${gitlabSourceRepoName}:
-                url: 'https://$GIT_HOSTNAME/${gitlabSourceRepoName}.git'

--- a/jobs/scm/katello_gitlab.yaml
+++ b/jobs/scm/katello_gitlab.yaml
@@ -5,14 +5,8 @@
           wipe-workspace: true
           skip-tag: true
           basedir: 'plugin'
-          merge:
-            remote: origin
-            branch: ${gitlabTargetBranch}
-            fast-forward-mode: NO_FF
           branches:
-            - ${gitlabSourceRepoName}/${gitlabSourceBranch}
+            - ${gitlabTargetBranch}
           remotes:
             - origin:
                 url: 'https://$GIT_HOSTNAME/$GIT_ORGANIZATION/katello.git'
-            - ${gitlabSourceRepoName}:
-                url: 'https://$GIT_HOSTNAME/${gitlabSourceRepoName}.git'

--- a/jobs/scm/smart_proxy_gitlab.yaml
+++ b/jobs/scm/smart_proxy_gitlab.yaml
@@ -4,14 +4,8 @@
       - git:
           wipe-workspace: true
           skip-tag: true
-          merge:
-            remote: origin
-            branch: ${gitlabTargetBranch}
-            fast-forward-mode: NO_FF
           branches:
-            - ${gitlabSourceRepoName}/${gitlabSourceBranch}
+            - ${gitlabTargetBranch}
           remotes:
             - origin:
                 url: 'https://$GIT_HOSTNAME/$GIT_ORGANIZATION/smart-proxy.git'
-            - ${gitlabSourceRepoName}:
-                url: 'https://$GIT_HOSTNAME/${gitlabSourceRepoName}.git'

--- a/scripts/merge_request.sh
+++ b/scripts/merge_request.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -ex
+
+if [ -n "${gitlabSourceBranch}" ]; then
+  git remote add pr https://$GIT_HOSTNAME/${gitlabSourceRepoName}.git
+  git fetch pr
+  git merge pr/${gitlabSourceBranch}
+fi


### PR DESCRIPTION
This moves the merge request merging into a script to allow the
same job to be used to run tests on a target branch as well as
handle merge requests (versus having two separate jobs).