### PR TITLE
Use RSA private key instead of DSA

### DIFF
--- a/jobs/satellite5-installer.yaml
+++ b/jobs/satellite5-installer.yaml
@@ -6,7 +6,7 @@
         <p>Job that just install <strong>Satellite 5</strong> on a machine.</p>
         <p>Please make sure to add the following <strong>ssh key</strong> to your server so that this <strong>Jenkins</strong> job can access it.</p>
         <pre>
-          ssh-dss AAAAB3NzaC1kc3MAAACBAP2+EVkCT6dJzwL5LFDX0ACzbtlDasmpXbC5dpPNiWmADfdpRdDjWtVA/xjbSOT5tTuLr5fi6cQ2VMLNgVoQUT7tlPAJJU5Z7BngR6CkmonSlczLWbqyJVxg7At/o/kzzYFLE+i1+ReGlXasv4kOlPxhwhqm/wO0hzdImcc866qfAAAAFQDZ8h1+tp6S6KkAahfQUBfgrYhXZQAAAIBJUgNuQZw4ZJ81CPmYDkkYrGbMKxlPn7p/Mycxz+pZi6GbLuaY8rzbhiwS1JcOpUKuB0r4PX6qUoQvhRYZdhfaSEGX81K/3EGpjbzvcFSXa/8ymCcvw9oDoFFV6HWtWxEbjmy9kGrmHMeyFfFAK/tvNbwxDnn2usA4P7UX2NrqUgAAAIEAoVFEn7VZOn7mZZGkBa9Zrtm4AOQEbqd03UoYE1til96Z0Hja8rs6ilqYwuT57VzoePh2uIPfCgzeUxQ+RDjku3YLBsMNRwz3yS49iNiRWF1PAfqscLYyHAFPvvxDE1D/5dHtQGkad618nepycGf+cuSNzZjJdbbbT+qDCm+K6PY= hudson@statler.usersys.redhat.com
+        ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAzoPajR2xtQOAfBebX69Mx9Ee4P/LMqlxQLKvF0bc79/1ayMf3IrmpY1V6JCpABvMV1830I9D9x9Tr8E9zjg2wWT14hhHsrUKSWUsy3doIwz3MtISBZPMig5AizVjH6Wl/t833zgkeHtStCYI/bmJQykj6AgB8/A4L5SRIpNnl1q7V+sw37Rmumaiqu4lRDXyTXY7mlOCuxrus/WcGyVTh2k+oBVqkz2V2s3+Or8Zy2Y441B4z3vF3lE6aoIBwidBVZ1LKaofZDMRf/lu575cI4AB3N5DQvpqwLSc4+HIvog0FdKUo3qMaFgg0KNkYS5fnpDpRDRQnFw7oFnBHiPNqw== jenkins@satellite-jenkins
         </pre>
     node: sesame
     parameters:

--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -97,7 +97,7 @@
                     DISTRIBUTION='satellite6-downstream'
                 fi
 
-                fab -H "root@$PROVISIONING_HOST" -i ~/.ssh/id_hudson_dsa "product_install:$DISTRIBUTION,create_vm=true,sat_cdn_version=$SATELLITE_VERSION,test_in_stage=$STAGE_TEST"
+                fab -H "root@$PROVISIONING_HOST" "product_install:$DISTRIBUTION,create_vm=true,sat_cdn_version=$SATELLITE_VERSION,test_in_stage=$STAGE_TEST"
                 # Write a properties file to allow passing variables to other build steps
                 echo "SERVER_HOSTNAME=$TARGET_IMAGE.$VM_DOMAIN" > build_env.properties
                 echo "TOOLS_REPO=$TOOLS_URL" >> build_env.properties

--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -6,7 +6,7 @@
         <p>Job that just install <strong>Satellite 6</strong> on a machine.</p>
         <p>Please make sure to add the following <strong>ssh key</strong> to your server so that this <strong>Jenkins</strong> job can access it.</p>
         <pre>
-          ssh-dss AAAAB3NzaC1kc3MAAACBAP2+EVkCT6dJzwL5LFDX0ACzbtlDasmpXbC5dpPNiWmADfdpRdDjWtVA/xjbSOT5tTuLr5fi6cQ2VMLNgVoQUT7tlPAJJU5Z7BngR6CkmonSlczLWbqyJVxg7At/o/kzzYFLE+i1+ReGlXasv4kOlPxhwhqm/wO0hzdImcc866qfAAAAFQDZ8h1+tp6S6KkAahfQUBfgrYhXZQAAAIBJUgNuQZw4ZJ81CPmYDkkYrGbMKxlPn7p/Mycxz+pZi6GbLuaY8rzbhiwS1JcOpUKuB0r4PX6qUoQvhRYZdhfaSEGX81K/3EGpjbzvcFSXa/8ymCcvw9oDoFFV6HWtWxEbjmy9kGrmHMeyFfFAK/tvNbwxDnn2usA4P7UX2NrqUgAAAIEAoVFEn7VZOn7mZZGkBa9Zrtm4AOQEbqd03UoYE1til96Z0Hja8rs6ilqYwuT57VzoePh2uIPfCgzeUxQ+RDjku3YLBsMNRwz3yS49iNiRWF1PAfqscLYyHAFPvvxDE1D/5dHtQGkad618nepycGf+cuSNzZjJdbbbT+qDCm+K6PY= hudson@statler.usersys.redhat.com
+        ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAzoPajR2xtQOAfBebX69Mx9Ee4P/LMqlxQLKvF0bc79/1ayMf3IrmpY1V6JCpABvMV1830I9D9x9Tr8E9zjg2wWT14hhHsrUKSWUsy3doIwz3MtISBZPMig5AizVjH6Wl/t833zgkeHtStCYI/bmJQykj6AgB8/A4L5SRIpNnl1q7V+sw37Rmumaiqu4lRDXyTXY7mlOCuxrus/WcGyVTh2k+oBVqkz2V2s3+Or8Zy2Y441B4z3vF3lE6aoIBwidBVZ1LKaofZDMRf/lu575cI4AB3N5DQvpqwLSc4+HIvog0FdKUo3qMaFgg0KNkYS5fnpDpRDRQnFw7oFnBHiPNqw== jenkins@satellite-jenkins
         </pre>
     node: sesame
     parameters:

--- a/jobs/satellite6-manifest-downloader.yaml
+++ b/jobs/satellite6-manifest-downloader.yaml
@@ -30,4 +30,4 @@
                 pip install -r requirements.txt
                 source $FAKE_CERT_CONFIG
                 source $SUBSCRIPTION_CONFIG
-                fab -H "root@$MANIFEST_SERVER_HOSTNAME" -i ~/.ssh/id_hudson_dsa relink_manifest
+                fab -H "root@$MANIFEST_SERVER_HOSTNAME" relink_manifest

--- a/jobs/satellite6-standalone-automation.yaml
+++ b/jobs/satellite6-standalone-automation.yaml
@@ -5,7 +5,7 @@
         <p>Job that runs robottelo on a machine.</p>
         <p>Please make sure to add the following <strong>ssh key</strong> to your server so that this <strong>Jenkins</strong> job can access it.</p>
         <pre>
-          ssh-dss AAAAB3NzaC1kc3MAAACBAP2+EVkCT6dJzwL5LFDX0ACzbtlDasmpXbC5dpPNiWmADfdpRdDjWtVA/xjbSOT5tTuLr5fi6cQ2VMLNgVoQUT7tlPAJJU5Z7BngR6CkmonSlczLWbqyJVxg7At/o/kzzYFLE+i1+ReGlXasv4kOlPxhwhqm/wO0hzdImcc866qfAAAAFQDZ8h1+tp6S6KkAahfQUBfgrYhXZQAAAIBJUgNuQZw4ZJ81CPmYDkkYrGbMKxlPn7p/Mycxz+pZi6GbLuaY8rzbhiwS1JcOpUKuB0r4PX6qUoQvhRYZdhfaSEGX81K/3EGpjbzvcFSXa/8ymCcvw9oDoFFV6HWtWxEbjmy9kGrmHMeyFfFAK/tvNbwxDnn2usA4P7UX2NrqUgAAAIEAoVFEn7VZOn7mZZGkBa9Zrtm4AOQEbqd03UoYE1til96Z0Hja8rs6ilqYwuT57VzoePh2uIPfCgzeUxQ+RDjku3YLBsMNRwz3yS49iNiRWF1PAfqscLYyHAFPvvxDE1D/5dHtQGkad618nepycGf+cuSNzZjJdbbbT+qDCm+K6PY= hudson@statler.usersys.redhat.com
+        ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAzoPajR2xtQOAfBebX69Mx9Ee4P/LMqlxQLKvF0bc79/1ayMf3IrmpY1V6JCpABvMV1830I9D9x9Tr8E9zjg2wWT14hhHsrUKSWUsy3doIwz3MtISBZPMig5AizVjH6Wl/t833zgkeHtStCYI/bmJQykj6AgB8/A4L5SRIpNnl1q7V+sw37Rmumaiqu4lRDXyTXY7mlOCuxrus/WcGyVTh2k+oBVqkz2V2s3+Or8Zy2Y441B4z3vF3lE6aoIBwidBVZ1LKaofZDMRf/lu575cI4AB3N5DQvpqwLSc4+HIvog0FdKUo3qMaFgg0KNkYS5fnpDpRDRQnFw7oFnBHiPNqw== jenkins@satellite-jenkins
         </pre>
     parameters:
         - string:

--- a/jobs/satellite6-upgrader.yaml
+++ b/jobs/satellite6-upgrader.yaml
@@ -8,7 +8,7 @@
         <p> This ssh key will be added to satellite and capsule instance to execute upgrade steps.</p>
         <p><strong>SSH KEY:</strong></p>
         <pre>
-          ssh-dss AAAAB3NzaC1kc3MAAACBAP2+EVkCT6dJzwL5LFDX0ACzbtlDasmpXbC5dpPNiWmADfdpRdDjWtVA/xjbSOT5tTuLr5fi6cQ2VMLNgVoQUT7tlPAJJU5Z7BngR6CkmonSlczLWbqyJVxg7At/o/kzzYFLE+i1+ReGlXasv4kOlPxhwhqm/wO0hzdImcc866qfAAAAFQDZ8h1+tp6S6KkAahfQUBfgrYhXZQAAAIBJUgNuQZw4ZJ81CPmYDkkYrGbMKxlPn7p/Mycxz+pZi6GbLuaY8rzbhiwS1JcOpUKuB0r4PX6qUoQvhRYZdhfaSEGX81K/3EGpjbzvcFSXa/8ymCcvw9oDoFFV6HWtWxEbjmy9kGrmHMeyFfFAK/tvNbwxDnn2usA4P7UX2NrqUgAAAIEAoVFEn7VZOn7mZZGkBa9Zrtm4AOQEbqd03UoYE1til96Z0Hja8rs6ilqYwuT57VzoePh2uIPfCgzeUxQ+RDjku3YLBsMNRwz3yS49iNiRWF1PAfqscLYyHAFPvvxDE1D/5dHtQGkad618nepycGf+cuSNzZjJdbbbT+qDCm+K6PY= hudson@statler.usersys.redhat.com
+        ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAzoPajR2xtQOAfBebX69Mx9Ee4P/LMqlxQLKvF0bc79/1ayMf3IrmpY1V6JCpABvMV1830I9D9x9Tr8E9zjg2wWT14hhHsrUKSWUsy3doIwz3MtISBZPMig5AizVjH6Wl/t833zgkeHtStCYI/bmJQykj6AgB8/A4L5SRIpNnl1q7V+sw37Rmumaiqu4lRDXyTXY7mlOCuxrus/WcGyVTh2k+oBVqkz2V2s3+Or8Zy2Y441B4z3vF3lE6aoIBwidBVZ1LKaofZDMRf/lu575cI4AB3N5DQvpqwLSc4+HIvog0FdKUo3qMaFgg0KNkYS5fnpDpRDRQnFw7oFnBHiPNqw== jenkins@satellite-jenkins
         </pre>
         <p> If this ssh key is not added already in your openstack project, please add it before running this job. Else the job will fail.</p>
     node: sesame

--- a/scripts/generate_source.rb
+++ b/scripts/generate_source.rb
@@ -18,7 +18,7 @@ Dir.chdir(ENV['repository']) do
     system("git archive | bzip2 -9 > #{artifact}")
   end
 
-  system("scp -i ~/.ssh/id_hudson_dsa #{artifact} jenkins@#{ENV['SOURCE_FILE_HOST']}:/var/www/html/pub/sources/6.2")
+  system("scp #{artifact} jenkins@#{ENV['SOURCE_FILE_HOST']}:/var/www/html/pub/sources/6.2")
 end
 
 system("rm -rf #{ENV['repository']}")

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -1,7 +1,7 @@
 pip install -U -r requirements.txt
 
 # Figure out what version of RHEL the server uses
-export OS_VERSION=$(fab -i ~/.ssh/id_hudson_dsa -H root@${SERVER_HOSTNAME} distro_info | grep "rhel [[:digit:]]" | cut -d ' ' -f 2)
+export OS_VERSION=$(fab -H root@${SERVER_HOSTNAME} distro_info | grep "rhel [[:digit:]]" | cut -d ' ' -f 2)
 
 
 source ${INSTALL_CONFIG}
@@ -16,11 +16,11 @@ else
 fi
 
 if [ ${FIX_HOSTNAME} = "true" ]; then
-    fab -i ~/.ssh/id_hudson_dsa -H root@${SERVER_HOSTNAME} fix_hostname
+    fab -H root@${SERVER_HOSTNAME} fix_hostname
 fi
 
 if [ ${PARTITION_DISK} = "true" ]; then
-    fab -i ~/.ssh/id_hudson_dsa -H root@${SERVER_HOSTNAME} partition_disk
+    fab -H root@${SERVER_HOSTNAME} partition_disk
 fi
 
 
@@ -39,9 +39,9 @@ if [ ${DISTRIBUTION} = "DOWNSTREAM" ]; then
     fi
 fi
 
-fab -i ~/.ssh/id_hudson_dsa -H root@${SERVER_HOSTNAME} product_install:satellite6-${DISTRIBUTION},sat_cdn_version=${SATELLITE_VERSION},test_in_stage=${STAGE_TEST}
+fab -H root@${SERVER_HOSTNAME} product_install:satellite6-${DISTRIBUTION},sat_cdn_version=${SATELLITE_VERSION},test_in_stage=${STAGE_TEST}
 
 if [ ${SETUP_FAKE_MANIFEST_CERTIFICATE} = "true" ]; then
     source $FAKE_CERT_CONFIG
-    fab -i ~/.ssh/id_hudson_dsa -H root@${SERVER_HOSTNAME} setup_fake_manifest_certificate
+    fab -H root@${SERVER_HOSTNAME} setup_fake_manifest_certificate
 fi

--- a/scripts/installer5.sh
+++ b/scripts/installer5.sh
@@ -4,15 +4,15 @@ source ${SUBSCRIPTION_CONFIG}
 source ${SAT5_CERT_CONFIG}
 
 if [ ${FIX_HOSTNAME} = "true" ]; then
-    fab -i ~/.ssh/id_hudson_dsa -H root@${SERVER_HOSTNAME} fix_hostname
+    fab -H root@${SERVER_HOSTNAME} fix_hostname
 fi
 
 if [ ${PARTITION_DISK} = "true" ]; then
-    fab -i ~/.ssh/id_hudson_dsa -H root@${SERVER_HOSTNAME} partition_disk
+    fab -H root@${SERVER_HOSTNAME} partition_disk
 fi
 
 # Figure out what version of RHEL the server uses
-OS_VERSION=$(fab -i ~/.ssh/id_hudson_dsa -H root@${SERVER_HOSTNAME} distro_info | grep "rhel [[:digit:]]" | cut -d ' ' -f 2)
+OS_VERSION=$(fab -H root@${SERVER_HOSTNAME} distro_info | grep "rhel [[:digit:]]" | cut -d ' ' -f 2)
 # export chosen Jenkins job parameters for usage by fabric
 export RHN_PROFILE="robottelo_${SERVER_HOSTNAME}"
 
@@ -24,4 +24,4 @@ if [ ${DISTRIBUTION} = "CANDIDATE" ]; then
     export ISO_URL="http://download/devel/candidates/latest-link-Satellite-5.7.0-RHEL${OS_VERSION}-x86_64/iso/"
 fi
 
-fab -i ~/.ssh/id_hudson_dsa -H root@${SERVER_HOSTNAME} satellite5_product_install
+fab -H root@${SERVER_HOSTNAME} satellite5_product_install

--- a/scripts/satellite6_upgrader.sh
+++ b/scripts/satellite6_upgrader.sh
@@ -18,4 +18,4 @@ export CAPSULE_URL="${CAPSULE_REPO}"
 export TOOLS_URL="${TOOLS_REPO}"
 
 # Run upgrade
-fab -i ~/.ssh/id_hudson_dsa -u root product_upgrade:"${PRODUCT}","${SSH_KEY_NAME}","${SATELLITE_INSTANCE}","${SATELLITE_IMAGE}","${IMAGE_FLAVOR}","${CAPSULE_INSTANCE}","${CAPSULE_IMAGE}","${IMAGE_FLAVOR}"
+fab -u root product_upgrade:"${PRODUCT}","${SSH_KEY_NAME}","${SATELLITE_INSTANCE}","${SATELLITE_IMAGE}","${IMAGE_FLAVOR}","${CAPSULE_INSTANCE}","${CAPSULE_IMAGE}","${IMAGE_FLAVOR}"


### PR DESCRIPTION
Starting at version 7.0, OpenSSH started a deprecation process in order
to drop less secure keys and protocols, like DSA public key algorithm
and they recommend against its use.

From the release notes [1]:

    Support for ssh-dss, ssh-dss-cert-* host and user keys is disabled
    by default at run-time. These may be re-enabled using the
    instructions at http://www.openssh.com/legacy.html

[1] http://www.openssh.com/txt/release-7.0