### PR TITLE
Improve betelgeuse jobs

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -380,6 +380,8 @@
                 TOOLS_URL=${RHEL7_TOOLS_URL}
                 SELINUX_MODE=${SELINUX_MODE}
                 BUILD_LABEL=${BUILD_LABEL}
+        - trigger-builds:
+            - project: satellite6-betelgeuse-test-case
 
 - job:
     name: satellite6-iso-trigger

--- a/scripts/satellite6-betelgeuse.sh
+++ b/scripts/satellite6-betelgeuse.sh
@@ -1,4 +1,5 @@
-git clone ${PYLARION_REPO_URL}
+rm -rf pylarion
+git clone --depth 1 ${PYLARION_REPO_URL}
 
 # Make pylarion ready to be installed on a virtual environment
 cd pylarion
@@ -12,7 +13,8 @@ pip install .
 cd ..
 
 # Install testimony from master
-git clone https://github.com/SatelliteQE/testimony.git
+rm -rf testimony
+git clone --depth 1 https://github.com/SatelliteQE/testimony.git
 cd testimony
 pip install .
 cd ..


### PR DESCRIPTION
Make sure to remove cloned pylarion directory before trying to clone
again.

Trigger satellite6-betelgeuse-test-case when triggering downstream
automation to make sure that when the test run job run all test cases is
going to be updated.

Close #138