### PR TITLE
Only archive foreman-debug if it is available

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -130,6 +130,7 @@
             script-only-if-failed: true
         - archive:
             artifacts: 'foreman-debug.tar.xz'
+            allow-empty: true
 
 - job-template:
     name: 'satellite6-automation-{distribution}-{os}-tier1'


### PR DESCRIPTION
foreman-debug will run on Satellite 6 provisioning jobs just when the
installation fail in order to capture more information. Since it will
not be available if the build succeed, its archiving should be marked as
optional.

Close #141