### PR TITLE
Some fianl fixes to builder job

### DIFF
--- a/jobs/satellite6-builder.yaml
+++ b/jobs/satellite6-builder.yaml
@@ -96,7 +96,7 @@
     collection: 'foreman-packaging'
     package:
         - 'tfm'
-    tito-release: 'dist-git-sat'
+    tito-release: 'tfm-dist-git-sat'
     jobs:
         - 'satellite6-packaging-builder-{package}'
 

--- a/scripts/satellite-packaging-builder.sh
+++ b/scripts/satellite-packaging-builder.sh
@@ -48,6 +48,7 @@ mk_yum_repo() {
     echo "baseurl=\"$repourl\""
     echo "enabled=$enabled"
     echo "gpgcheck=$gpgcheck"
+    echo "skip_if_unavailable=True"
 }
 
 symbol_str() {


### PR DESCRIPTION
- Building 'tfm' with the 'tfm-dist-git-sat' releaser
- Ignoring dependecy content views from Satellite when they don't exist
  yet