### PR TITLE
Change cachingpolicy when installing pylarion

### DIFF
--- a/scripts/satellite6-betelgeuse.sh
+++ b/scripts/satellite6-betelgeuse.sh
@@ -6,6 +6,7 @@ cd pylarion
 cp setup.py setup.py.old
 head -n -3 setup.py.old > setup.py
 sed -i "s|'/etc', ||" setup.py
+sed -i "s/cachingpolicy=1/cachingpolicy=0/" src/pylarion/session.py
 
 # Install pylarion and its dependencies
 pip install -r requirements.txt


### PR DESCRIPTION
For some reason the caching policy 1 is not working well with the load
balancer and because that authentication is failing. This is a
workaround while the real cause is not found yet.