### PR TITLE
Allows installer options to be passed to the installer when doing a p…

### DIFF
--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -95,6 +95,14 @@
             description: |
                 This is required when we need to set a custom DHCP range.
                 Completely Optional but would be helpful to have.
+        - string:
+            name: INSTALLER_OPTIONS
+            description: |
+                Can pass katello-installer options. Helpful to quickly
+                configure ad-hoc stuff without the need to have each installer
+                option separately. This is not validated in any way, so the
+                user needs to provide valid input. Completely Optional.
+                For example: foreman-proxy-dhcp=false,foreman-proxy-dns=false
     scm:
         - git:
             url: https://github.com/SatelliteQE/automation-tools.git


### PR DESCRIPTION
…roduct_install

    *) Helps in passing ad-hoc options to katello-installer at runtime,
       which is while installing a satellite6 using sat6-installer.
    *) Could also be helpful when we need to disable certain buggy
       capsule features and just proceed with the required stable
       sat6 setup.