### PR TITLE
Limit the depth of foreman-infra cloning

### DIFF
--- a/setup_jjb.sh
+++ b/setup_jjb.sh
@@ -9,7 +9,7 @@ rm -rf _build
 mkdir _build
 cd _build
 
-git clone https://github.com/theforeman/foreman-infra.git
+git clone --depth 1 https://github.com/theforeman/foreman-infra.git
 cd ..
 
 cp -rf _build/foreman-infra/puppet/modules/jenkins_job_builder/files/theforeman.org foreman-infra


### PR DESCRIPTION
This is going to make cloning the foreman-infra repo faster. Better for
Travis runs and also for robottelo-ci update job runs.