### PR TITLE
job param to enable beaker repo for OS upgrade before sat6 install

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -49,6 +49,10 @@
                 Points to RHSM stage for stage installation test. Used only
                 in CDN provisioning.
         - string:
+            name: OS_UPGRADE_REPO
+            description: |
+                Upgrade OS using this repo URL (typically OS candidate repo).  
+        - string:
             name: BUILD_LABEL
     scm:
         - git:


### PR DESCRIPTION
This is robottelo-ci part for SatelliteQE/automation-tools PR #300.