### PR TITLE
Updated git clone to use ssh

### DIFF
--- a/jobs/satellite6-closed-loop.yaml
+++ b/jobs/satellite6-closed-loop.yaml
@@ -5,7 +5,7 @@
         <p>Job that runs closed loop process</p>
     scm:
         - git:
-            url: 'https://$GIT_HOSTNAME/$GIT_QE_ORGANIZATION/closed-loop.git'
+            url: 'git@$GIT_HOSTNAME:$GIT_QE_ORGANIZATION/closed-loop.git'
             branches:
                 - origin/master
             skip-tag: true


### PR DESCRIPTION
Using https gave connection git connection refused errors.  I tested jenkins with this new change and it worked fine.