### PR TITLE
Follow naming convention on performance report job

### DIFF
--- a/jobs/satellite6-automation-performance-report.yaml
+++ b/jobs/satellite6-automation-performance-report.yaml
@@ -8,7 +8,7 @@
                 - rhel6
                 - rhel7
         - string:
-            name: LABEL
+            name: BUILD_LABEL
         - file:
             name: JUNIT
     scm:

--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -147,7 +147,7 @@
                 - project: 'satellite6-automation-performance-report'
                   predefined-parameters: |
                     OS={os}
-                    LABEL=${{LABEL}}
+                    BUILD_LABEL=${{BUILD_LABEL}}
                   parameter-factories:
                     - factory: binaryfile
                       parameter-name: JUNIT


### PR DESCRIPTION
Change LABEL to BUILD_LABEL in order to have the same name for the same
information through out the Satellite 6 automation.