### PR TITLE
updated zstream branch from 6.0.z to 6.1.z

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -374,7 +374,7 @@
         - cdn
         - downstream
         - zstream:
-            scm-branch: origin/satellite-6.0.z.1
+            scm-branch: origin/satellite-6.1.z
         - iso
         - upstream
     os:


### PR DESCRIPTION
I'm not sure if that's the only change.. but currently job for tier1 tests is failing due to:

```
git rev-parse origin/satellite-6.0.z.1^{commit} ERROR: Couldn't find any revision to build.
```
I simply changed the zstream branch to 6.0.z to 6.1.z and I don't think we will get any zstream for 6.0 