### PR TITLE
Fix performance report job

### DIFF
--- a/scripts/satellite6-automation-performance-report.sh
+++ b/scripts/satellite6-automation-performance-report.sh
@@ -4,4 +4,4 @@ if [ ! -f ~/satellite_performance_data.csv ]; then
    touch ~/satellite_performance_data.csv
 fi
 
-./performance_report.py ${OS} ${BUILD_LABEL} ${JUNIT}
+./performance_report.py ${OS} ${BUILD_LABEL} JUNIT


### PR DESCRIPTION
Jenkins provide the file parameter with the same name of the parameter.
Update the performance report script to pass the right path.