### PR TITLE
Update standalone automation job script

### DIFF
--- a/scripts/satellite6-standalone-automation.sh
+++ b/scripts/satellite6-standalone-automation.sh
@@ -11,7 +11,7 @@ sed -i "s/^admin_username.*/admin_username=${FOREMAN_ADMIN_USER}/" robottelo.pro
 sed -i "s/^admin_password.*/admin_password=${FOREMAN_ADMIN_PASSWORD}/" robottelo.properties
 
 pytest() {
-    $(which py.test) -v --junit-xml=foreman-results.xml -m 'not stubbed' $1
+    $(which py.test) -v --junit-xml=foreman-results.xml -m "not stubbed" "$@"
 }
 
 if [ -n "${PYTEST_OPTIONS:-}" ]; then


### PR DESCRIPTION
Make sure to read all options passed as PYTEST_OPTIONS and also fix the
call when the options are passed.

Thanks @omaciel for catching this bug.