### PR TITLE
Added ability to supply custom url for iso install

### DIFF
--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -74,10 +74,11 @@
         - string:
             name: SATELLITE6_CUSTOM_BASEURL
             description: |
-                Used only in Downstream provisioning.  Provide baseurl for
+                Used in Downstream/ISO provisioning only.  Provide baseurl for
                 satellite install.  Note that this uses the given url for
                 installation without any validation.  It is the responsibility
-                of the user to provide a valid rhel6/rhel7 URL.
+                of the user to provide a valid rhel6/rhel7 URL. For ISO, you
+                can provide the url or the iso.
         - string:
             name: INTERFACE
             description: |

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -26,7 +26,12 @@ fi
 
 # ISOs require a specific URL
 if [ ${DISTRIBUTION} = "ISO" ]; then
-    export ISO_URL="${SATELLITE6_ISO_REPO}"
+    # If user provided custom baseurl, use it otherwise use the default
+    if [ ! -z "$SATELLITE6_CUSTOM_BASEURL" ]; then
+        export ISO_URL="${SATELLITE6_CUSTOM_BASEURL}"
+    else
+        export ISO_URL="${SATELLITE6_ISO_REPO}"
+    fi  
 fi
 
 # This is only used for downstream builds


### PR DESCRIPTION
Until today, user was able to install iso from latest stable only.  This change will enable user to supply custom iso urls.