### PR TITLE
Run transitioning tests in serial

### DIFF
--- a/jobs/publishers/satellite6_automation_publishers.yaml
+++ b/jobs/publishers/satellite6_automation_publishers.yaml
@@ -4,6 +4,6 @@
         - archive:
             artifacts: 'test-foreman-*.svg,robottelo*.log,insights*.log,foreman-results.xml'
         - junit:
-            results: 'foreman-results.xml'
+            results: '*-results.xml'
             claim-build: true
         - claim-build

--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -39,6 +39,11 @@ fi
 
 make test-foreman-${ENDPOINT} PYTEST_XDIST_NUMPROCESSES=4
 
+if [ "${ENDPOINT}" = "tier1" ]; then
+    $(which py.test) -v --junit-xml transitioning-results.xml \
+        -m 'not stubbed' tests/foreman/cli/test_import.py
+fi
+
 echo
 echo "========================================"
 echo "Server information"


### PR DESCRIPTION
Generate a separated jUnit XML file for the transitioning tests and let Jenkins
join the results when generating the report.

Depends on https://github.com/SatelliteQE/robottelo/pull/3366