### PR TITLE
Add package release workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ foreman-infra
 *.pyc
 *.swp
 *.swn
+*.swo

--- a/jobs/release/projects/properties/branch.groovy
+++ b/jobs/release/projects/properties/branch.groovy
@@ -1,0 +1,1 @@
+def releaseBranch = 'SATELLITE-6.2.0'

--- a/jobs/release/projects/properties/foreman_docker_repo.groovy
+++ b/jobs/release/projects/properties/foreman_docker_repo.groovy
@@ -1,0 +1,1 @@
+def gitRepository = 'satellite6/foreman_docker'

--- a/jobs/release/projects/properties/foreman_installer_repo.groovy
+++ b/jobs/release/projects/properties/foreman_installer_repo.groovy
@@ -1,0 +1,1 @@
+def gitRepository = 'satellite6/foreman-installer'

--- a/jobs/release/projects/properties/foreman_openscap_repo.groovy
+++ b/jobs/release/projects/properties/foreman_openscap_repo.groovy
@@ -1,0 +1,1 @@
+def gitRepository = 'satellite6/foreman_openscap'

--- a/jobs/release/projects/properties/foreman_repo.groovy
+++ b/jobs/release/projects/properties/foreman_repo.groovy
@@ -1,0 +1,1 @@
+def gitRepository = 'satellite6/foreman'

--- a/jobs/release/projects/properties/foreman_theme_satellite_repo.groovy
+++ b/jobs/release/projects/properties/foreman_theme_satellite_repo.groovy
@@ -1,0 +1,1 @@
+def gitRepository = 'satellite6/foreman_theme_satellite'

--- a/jobs/release/projects/properties/hammer_cli_foreman_remote_execution_repo.groovy
+++ b/jobs/release/projects/properties/hammer_cli_foreman_remote_execution_repo.groovy
@@ -1,0 +1,1 @@
+def gitRepository = 'satellite6/hammer_cli_foreman_remote_execution'

--- a/jobs/release/projects/properties/katello_repo.groovy
+++ b/jobs/release/projects/properties/katello_repo.groovy
@@ -1,0 +1,1 @@
+def gitRepository = 'satellite6/katello'

--- a/jobs/release/projects/properties/smart_proxy_dynflow_repo.groovy
+++ b/jobs/release/projects/properties/smart_proxy_dynflow_repo.groovy
@@ -1,0 +1,1 @@
+def gitRepository = 'satellite6/smart_proxy_dynflow'

--- a/jobs/release/projects/properties/sourceTypeGem.groovy
+++ b/jobs/release/projects/properties/sourceTypeGem.groovy
@@ -1,0 +1,1 @@
+def sourceType = 'gem'

--- a/jobs/release/projects/properties/sourceTypeRake.groovy
+++ b/jobs/release/projects/properties/sourceTypeRake.groovy
@@ -1,0 +1,1 @@
+def sourceType = 'rake'

--- a/jobs/release/projects/properties/sourceTypeTar.groovy
+++ b/jobs/release/projects/properties/sourceTypeTar.groovy
@@ -1,0 +1,1 @@
+def sourceType = 'tar'

--- a/jobs/release/projects/sat62-release-foreman-docker.yaml
+++ b/jobs/release/projects/sat62-release-foreman-docker.yaml
@@ -1,0 +1,9 @@
+- job:
+    name: 'sat62-release-foreman-docker'
+    project-type: workflow
+    dsl:
+      !include-raw:
+          - properties/branch.groovy
+          - properties/foreman_docker_repo.groovy
+          - properties/sourceTypeGem.groovy
+          - workflows/releasePackageWorkflow.groovy

--- a/jobs/release/projects/sat62-release-foreman-installer.yaml
+++ b/jobs/release/projects/sat62-release-foreman-installer.yaml
@@ -1,0 +1,9 @@
+- job:
+    name: 'sat62-release-foreman-installer'
+    project-type: workflow
+    dsl:
+      !include-raw:
+          - properties/branch.groovy
+          - properties/foreman_installer_repo.groovy
+          - properties/sourceTypeRake.groovy
+          - workflows/releasePackageWorkflow.groovy

--- a/jobs/release/projects/sat62-release-foreman-openscap.yaml
+++ b/jobs/release/projects/sat62-release-foreman-openscap.yaml
@@ -1,0 +1,9 @@
+- job:
+    name: 'sat62-release-foreman-openscap'
+    project-type: workflow
+    dsl:
+      !include-raw:
+          - properties/branch.groovy
+          - properties/foreman_openscap_repo.groovy
+          - properties/sourceTypeGem.groovy
+          - workflows/releasePackageWorkflow.groovy

--- a/jobs/release/projects/sat62-release-foreman-theme-satellite.yaml
+++ b/jobs/release/projects/sat62-release-foreman-theme-satellite.yaml
@@ -1,0 +1,9 @@
+- job:
+    name: 'sat62-release-foreman-theme-satellite'
+    project-type: workflow
+    dsl:
+      !include-raw:
+          - properties/branch.groovy
+          - properties/foreman_theme_satellite_repo.groovy
+          - properties/sourceTypeGem.groovy
+          - workflows/releasePackageWorkflow.groovy

--- a/jobs/release/projects/sat62-release-foreman.yaml
+++ b/jobs/release/projects/sat62-release-foreman.yaml
@@ -1,0 +1,9 @@
+- job:
+    name: 'sat62-release-foreman'
+    project-type: workflow
+    dsl:
+      !include-raw:
+          - properties/branch.groovy
+          - properties/foreman_repo.groovy
+          - properties/sourceTypeTar.groovy
+          - workflows/releasePackageWorkflow.groovy

--- a/jobs/release/projects/sat62-release-hammer-cli-foreman-remote-execution.yaml
+++ b/jobs/release/projects/sat62-release-hammer-cli-foreman-remote-execution.yaml
@@ -1,0 +1,9 @@
+- job:
+    name: 'sat62-release-hammer-cli-foreman-remote-execution'
+    project-type: workflow
+    dsl:
+      !include-raw:
+          - properties/branch.groovy
+          - properties/hammer_cli_foreman_remote_execution_repo.groovy
+          - properties/sourceTypeGem.groovy
+          - workflows/releasePackageWorkflow.groovy

--- a/jobs/release/projects/sat62-release-katello.yaml
+++ b/jobs/release/projects/sat62-release-katello.yaml
@@ -1,0 +1,9 @@
+- job:
+    name: 'sat62-release-katello'
+    project-type: workflow
+    dsl:
+      !include-raw:
+          - properties/branch.groovy
+          - properties/katello_repo.groovy
+          - properties/sourceTypeGem.groovy
+          - workflows/releasePackageWorkflow.groovy

--- a/jobs/release/projects/sat62-release-smart-proxy-dynflow.yaml
+++ b/jobs/release/projects/sat62-release-smart-proxy-dynflow.yaml
@@ -1,0 +1,9 @@
+- job:
+    name: 'sat62-release-smart-proxy-dynflow'
+    project-type: workflow
+    dsl:
+      !include-raw:
+          - properties/branch.groovy
+          - properties/smart_proxy_dynflow_repo.groovy
+          - properties/sourceTypeGem.groovy
+          - workflows/releasePackageWorkflow.groovy

--- a/workflows/releasePackageWorkflow.groovy
+++ b/workflows/releasePackageWorkflow.groovy
@@ -1,0 +1,76 @@
+import groovy.json.JsonSlurper
+
+node('rhel') {
+    stage "Identify Bugs"
+
+        def repoName = gitRepository.split('/')[1]
+        def releaseTag = ''
+
+        dir(repoName) {
+            withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'jenkins-gitlab', passwordVariable: 'PASSWORD', usernameVariable: 'USERNAME']]) {
+            
+                git url: "https://${env.USERNAME}:${env.PASSWORD}@${env.GIT_HOSTNAME}/${gitRepository}.git", branch: releaseBranch
+
+            }
+        }
+
+        dir('tool_belt') {
+            git url: "https://${env.GIT_HOSTNAME}/satellite6/tool_belt.git", branch: 'master'
+            sh 'bundle install'
+        }
+
+        dir(repoName) {
+            sh "../tool_belt/tools.rb release find-bz-ids --output-file bz_ids.json"
+            archive 'bz_ids.json'
+        }
+
+
+    stage "Move Bugs to Modified"
+    
+        dir(repoName) {
+            def ids = readFile 'bz_ids.json'
+            ids = new JsonSlurper().parseText(ids)
+            ids = ids.join(' --bug ')
+  
+            withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'bugzilla-credentials', passwordVariable: 'BZ_PASSWORD', usernameVariable: 'BZ_USERNAME']]) {
+    
+                echo ids.toString()
+                sh "../tool_belt/tools.rb bugzilla move-to-modified --username ${env.BZ_USERNAME} --password ${env.BZ_PASSWORD} --bug ${ids}"
+  
+            }
+        }
+
+
+    stage "Bump Version"
+            
+        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'jenkins-gitlab', passwordVariable: 'PASSWORD', usernameVariable: 'USERNAME']]) {
+
+            dir(repoName) {
+                sh "git config user.email 'sat6-jenkins@redhat.com'"
+                sh "git config user.name 'Jenkins'"
+
+                sh "../tool_belt/tools.rb release bump-version --output-file version.json"
+                archive "version.json"
+                releaseTag = readFile 'version.json'
+
+                sh "git push origin ${releaseBranch}"
+                sh "git push origin ${releaseTag}"
+            }
+
+        }
+
+
+    stage "Build Source"
+
+        dir(repoName) {
+
+            def artifact = ''            
+
+            sh "../tool_belt/tools.rb release build-source --type ${sourceType} --output-file artifact"
+            artifact = readFile 'artifact'
+            
+            sh "scp ${artifact} jenkins@${env.SOURCE_FILE_HOST}:/var/www/html/pub/sources/6.2"
+
+        }
+
+}


### PR DESCRIPTION
For now this is a placeholder, as its generic to any package that needs released, but I would like to split it out so that each repository and thus package have their own set of jobs instead of a generic parameterized one.