### PR TITLE
Save Robottelo screenshots on Working Directory

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -7,6 +7,7 @@ fi
 cp ${ROBOTTELO_CONFIG} ./robottelo.properties
 
 sed -i "s/{server_hostname}/${SERVER_HOSTNAME}/" robottelo.properties
+sed -i "s|# screenshots_path=.*|screenshots_path=$(pwd)/screenshots|" robottelo.properties
 
 # Robottelo logging configuration
 sed -i "s/'\(robottelo\).log'/'\1-${ENDPOINT}.log'/" logging.conf


### PR DESCRIPTION
Edit the robottelo.properties screenshots_path in order to store them on the
working directory of each job.