### PR TITLE
Include tier1 transitioning results

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -305,9 +305,11 @@
         - shell: rm -f *.xml
         - copyartifact:
             project: 'satellite6-automation-downstream-{os}-tier1'
-            filter: 'foreman-results.xml'
+            filter: '*-results.xml'
             which-build: last-successful
-        - shell: mv foreman-results.xml tier1-results.xml
+        - shell: |
+            mv foreman-results.xml tier1-results.xml
+            mv transitioning-results.xml tier1-transitioning-results.xml
         - copyartifact:
             project: 'satellite6-automation-downstream-{os}-tier2'
             filter: 'foreman-results.xml'

--- a/jobs/satellite6-betelgeuse.yaml
+++ b/jobs/satellite6-betelgeuse.yaml
@@ -46,9 +46,11 @@
     builders:
         - copyartifact:
             project: satellite6-automation-downstream-{os}-tier1
-            filter: 'foreman-results.xml'
+            filter: '*-results.xml'
             which-build: workspace-latest
-        - shell: mv foreman-results.xml tier1-results.xml
+        - shell: |
+            mv foreman-results.xml tier1-results.xml
+            mv transitioning-results.xml tier1-transitioning-results.xml
         - copyartifact:
             project: satellite6-automation-downstream-{os}-tier2
             filter: 'foreman-results.xml'

--- a/scripts/satellite6-betelgeuse-test-run.sh
+++ b/scripts/satellite6-betelgeuse-test-run.sh
@@ -8,6 +8,13 @@ betelgeuse -j auto test-run \
     ${POLARION_DEFAULT_PROJECT}
 
 betelgeuse -j auto test-run \
+    --path tier1-transitioning-results.xml \
+    --test-run-id "${TEST_RUN_ID} - Tier 1" \
+    --test-template-id "${TEST_TEMPLATE_ID}" \
+    --user ${POLARION_USER} \
+    ${POLARION_DEFAULT_PROJECT}
+
+betelgeuse -j auto test-run \
     --path tier2-results.xml \
     --test-run-id "${TEST_RUN_ID} - Tier 2" \
     --test-template-id "${TEST_TEMPLATE_ID}" \


### PR DESCRIPTION
Include on Betelgeuse test run and also on the automation report the
transitioning results that are being run serially after the tier1 automation.