### PR TITLE
Publish all jUnit XML reports

### DIFF
--- a/jobs/publishers/satellite6_automation_publishers.yaml
+++ b/jobs/publishers/satellite6_automation_publishers.yaml
@@ -2,7 +2,7 @@
     name: satellite6-automation-publishers
     publishers:
         - archive:
-            artifacts: 'test-foreman-*.svg,robottelo*.log,insights*.log,foreman-results.xml'
+            artifacts: 'test-foreman-*.svg,robottelo*.log,insights*.log,*-results.xml'
         - junit:
             results: '*-results.xml'
             claim-build: true


### PR DESCRIPTION
Satellite 6 automation tier 1 publishes two jUnit XML reports, use a pattern to
archive all generated reports.