### PR TITLE
Fix Satellite 6 automation script

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -42,11 +42,13 @@ if [ "${ENDPOINT}" != "rhai" ]; then
     set +e
     # Run parallel tests
     $(which py.test) -v --junit-xml="${ENDPOINT}-parallel-results.xml" -n 4 \
-        --boxed -m "${ENDPOINT} and not run_in_one_thread and not stubbed"
+        --boxed -m "${ENDPOINT} and not run_in_one_thread and not stubbed" \
+        tests/foreman/{api,cli,ui,longrun}
 
     # Run sequential tests
-    $(which py.test) -v --junit-xml="${ENDPOINT}-sequential-results.xml" -n 4 \
-        --boxed -m "${ENDPOINT} and run_in_one_thread and not stubbed"
+    $(which py.test) -v --junit-xml="${ENDPOINT}-sequential-results.xml" \
+        -m "${ENDPOINT} and run_in_one_thread and not stubbed" \
+        tests/foreman/{api,cli,ui,longrun}
     set -e
 else
     make test-foreman-${ENDPOINT} PYTEST_XDIST_NUMPROCESSES=4


### PR DESCRIPTION
Restrict the paths to look for the tests in order to make sure to target the
right automation directories when running py.test.

Also fix a typo when running sequential tests.