### PR TITLE
Doubling the number of threads for automation run to 8.

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -41,7 +41,7 @@ fi
 if [ "${ENDPOINT}" != "rhai" ]; then
     set +e
     # Run parallel tests
-    $(which py.test) -v --junit-xml="${ENDPOINT}-parallel-results.xml" -n 4 \
+    $(which py.test) -v --junit-xml="${ENDPOINT}-parallel-results.xml" -n 8 \
         --boxed -m "${ENDPOINT} and not run_in_one_thread and not stubbed" \
         tests/foreman/{api,cli,ui,longrun}
 


### PR DESCRIPTION
This is an attempt to speed up the jenkins job runs.