### PR TITLE
Add PYTEST_MARKS param to standalone-automation

### DIFF
--- a/jobs/satellite6-standalone-automation.yaml
+++ b/jobs/satellite6-standalone-automation.yaml
@@ -48,6 +48,11 @@
                 <p><strong>If this parameter is not blank then the TEST_TYPE
                 parameter will be ignored</strong>.</p>
         - string:
+            name: PYTEST_MARKS
+            default: not stubbed
+            description: |
+                Specify the py.test marks you want to run or skip when specifying PYTEST_OPTIONS.
+        - string:
             name: ROBOTTELO_REPO
             default: https://github.com/SatelliteQE/robottelo.git
             description: |
@@ -59,7 +64,7 @@
                 You can override this to any branch. Example: 6.1.z
     scm:
         - git:
-            url: ${ROBOTTELO_REPO} 
+            url: ${ROBOTTELO_REPO}
             branches:
                 - origin/${ROBOTTELO_BRANCH}
             skip-tag: true

--- a/scripts/satellite6-standalone-automation.sh
+++ b/scripts/satellite6-standalone-automation.sh
@@ -15,7 +15,7 @@ sed -i "s/^admin_username.*/admin_username=${FOREMAN_ADMIN_USER}/" robottelo.pro
 sed -i "s/^admin_password.*/admin_password=${FOREMAN_ADMIN_PASSWORD}/" robottelo.properties
 
 pytest() {
-    $(which py.test) -v --junit-xml=foreman-results.xml -m "not stubbed" "$@"
+    $(which py.test) -v --junit-xml=foreman-results.xml -m "${PYTEST_MARKS}" "$@"
 }
 
 if [ -n "${PYTEST_OPTIONS:-}" ]; then


### PR DESCRIPTION
Add a separated parameter for the PYTEST_MARKS to be able to specify them,
without the parameter and passing direct to the PYTEST_OPTIONS it results
quoting issues.