### PR TITLE
Fix typo in reset command introduced in #279

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -45,7 +45,7 @@ if [ "${ENDPOINT}" != "rhai" ]; then
         echo "Resetting Satellite..."
         ssh root@"${SERVER_HOSTNAME}" "satellite-installer --reset"
         echo "Satellite Reset Complete"
-    if
+    fi
 
     # Run parallel tests
     $(which py.test) -v --junit-xml="${ENDPOINT}-parallel-results.xml" -n "${ROBOTTELO_WORKERS}" \


### PR DESCRIPTION
we missed an **if** in the place of **fi** so all automation failed.

(I did not re-started the automation because I had no access)