### PR TITLE
Adding missed parameter for satellite automation job

### DIFF
--- a/jobs/parameters/satellite6_automation_parameters.yaml
+++ b/jobs/parameters/satellite6_automation_parameters.yaml
@@ -23,3 +23,5 @@
         - string:
             name: DISCOVERY_ISO
             description: 'The discovery ISO name.'
+        - string:
+            name: ROBOTTELO_WORKERS

--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -56,6 +56,8 @@
                 in CDN provisioning.
         - string:
             name: BUILD_LABEL
+        - string:
+            name: ROBOTTELO_WORKERS
     scm:
         - git:
             url: https://github.com/SatelliteQE/automation-tools.git


### PR DESCRIPTION
The new parameter value is not passed to the respective jobs.  Adding the parameter in respective jobs.