### PR TITLE
Disable Resetting Satellite

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -39,15 +39,15 @@ if [[ "${DISTRIBUTION}" != *"cdn"* ]]; then
 fi
 
 if [ "${ENDPOINT}" != "rhai" ]; then
-    set +e
+    # set +e
     # Reset satellite at the start of tier2, tier3, tier4 jobs
-    if [[ "${ENDPOINT}" =~ tier[234] ]]; then 
-        echo "Resetting Satellite and applying workaround..."
-        ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -T root@"${SERVER_HOSTNAME}" <<-EOF
-		satellite-installer --reset
-		hammer -u admin -p changeme settings set --name=check_services_before_actions --value=false
-	EOF
-    fi
+    # if [[ "${ENDPOINT}" =~ tier[234] ]]; then
+    #    echo "Resetting Satellite and applying workaround..."
+    #    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -T root@"${SERVER_HOSTNAME}" <<-EOF
+    #		satellite-installer --reset
+    #		hammer -u admin -p changeme settings set --name=check_services_before_actions --value=false
+    #	EOF
+    # fi
 
     # Run parallel tests
     $(which py.test) -v --junit-xml="${ENDPOINT}-parallel-results.xml" -n "${ROBOTTELO_WORKERS}" \


### PR DESCRIPTION
*) Currently running satellite-installer --reset fails
*) This leaves the Satellite in an unusable state.