### PR TITLE
Allow generate_jobs.sh script to filter jobs

### DIFF
--- a/generate_jobs.sh
+++ b/generate_jobs.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-
-jenkins-jobs --conf jenkins_jobs.ini  -l debug test -r -o /tmp/jobs jobs:foreman-infra
+jenkins-jobs --conf jenkins_jobs.ini -l debug test -r -o /tmp/jobs jobs:foreman-infra "$@"


### PR DESCRIPTION
Allow generate_jobs.sh script to receive additional arguments to filter the
jobs which is needs to be generate for testing.