### PR TITLE
Set a default build history limit

### DIFF
--- a/jobs/defaults/defaults.yaml
+++ b/jobs/defaults/defaults.yaml
@@ -6,4 +6,8 @@
       changes, check out the
       <a href="https://github.com/SatelliteQE/robottelo-ci">robottelo-ci</a>
       repository.
-    logrotate: {}
+    logrotate:
+        numToKeep: 32
+    properties:
+        - build-discarder:
+            num-to-keep: 32


### PR DESCRIPTION
The default was to store everything but doing that will make disk usage very
high. Limit to 32 builds the history to make sure disk space will better used.