### PR TITLE
Remove initial snapshot from install test

### DIFF
--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -1,6 +1,4 @@
 #!/bin/bash -xe
 
 ssh jenkins@$LIBVIRT_HOST "cd sat-deploy && git -c http.sslVerify=false fetch origin && git reset origin/master --hard"
-ssh jenkins@$LIBVIRT_HOST "cd sat-deploy/lago/environment-rhel${rhel} && lago revert initial"
-ssh jenkins@$LIBVIRT_HOST "cd sat-deploy/lago/environment-rhel${rhel} && lago snapshot initial"
 ssh jenkins@$LIBVIRT_HOST "cd sat-deploy/lago && ./install-satellite.rb rhel${rhel}"


### PR DESCRIPTION
The install test has been updated to handle snapshotting within
the library itself versus through Jenkins.