### PR TITLE
Added support to reset sat6 instance using snapshot

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -140,13 +140,14 @@
         - satellite6-automation-wrappers
         - inject:
             properties-content: |
-                DISTRIBUTION={distribution}
+                DISTRIBUTION=satellite6-{distribution}
                 ENDPOINT=tier1
+                DISTRO={os}
     builders:
         - satellite6-automation-builders
         - conditional-step:
             condition-kind: regex-match
-            regex: (upstream|downstream|cdn|zstream)
+            regex: (satellite6-upstream|satellite6-downstream|satellite6-cdn|satellite6-zstream)
             label: ${{ENV,var="DISTRIBUTION"}}
             steps:
                 - trigger-builds:
@@ -154,7 +155,7 @@
                       current-parameters: true
         - conditional-step:
             condition-kind: regex-match
-            regex: (downstream)
+            regex: (satellite6-downstream)
             label: ${{ENV,var="DISTRIBUTION"}}
             steps:
               - trigger-builds:
@@ -185,8 +186,9 @@
         - satellite6-automation-wrappers
         - inject:
             properties-content: |
-                DISTRIBUTION={distribution}
+                DISTRIBUTION=satellite6-{distribution}
                 ENDPOINT=tier2
+                DISTRO={os}
     builders:
         - satellite6-automation-builders
         - trigger-builds:
@@ -210,13 +212,14 @@
         - satellite6-automation-wrappers
         - inject:
             properties-content: |
-                DISTRIBUTION={distribution}
+                DISTRIBUTION=satellite6-{distribution}
                 ENDPOINT=tier3
+                DISTRO={os}
     builders:
         - satellite6-automation-builders
         - conditional-step:
             condition-kind: regex-match
-            regex: (cdn|downstream|zstream)
+            regex: (satellite6-cdn|satellite6-downstream|satellite6-zstream)
             label: ${{ENV,var="DISTRIBUTION"}}
             steps:
                 - trigger-builds:
@@ -241,8 +244,9 @@
         - satellite6-automation-wrappers
         - inject:
             properties-content: |
-                DISTRIBUTION={distribution}
+                DISTRIBUTION=satellite6-{distribution}
                 ENDPOINT=rhai
+                DISTRO={os}
     builders:
         - satellite6-automation-builders
         - trigger-builds:
@@ -278,13 +282,14 @@
         - satellite6-automation-wrappers
         - inject:
             properties-content: |
-                DISTRIBUTION={distribution}
+                DISTRIBUTION=satellite6-{distribution}
                 ENDPOINT=tier4
+                DISTRO={os}
     builders:
         - satellite6-automation-builders
         - conditional-step:
             condition-kind: regex-match
-            regex: (downstream)
+            regex: (satellite6-downstream)
             label: ${{ENV,var="DISTRIBUTION"}}
             steps:
                 - trigger-builds:

--- a/jobs/wrappers/satellite6_automation_wrappers.yaml
+++ b/jobs/wrappers/satellite6_automation_wrappers.yaml
@@ -5,6 +5,8 @@
             files:
                 - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1431607187795
                   variable: ROBOTTELO_CONFIG
+                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1421176025129
+                  variable: PROVISIONING_CONFIG
         - workspace-cleanup:
             include:
                 - 'robottelo*.log'

--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -1,8 +1,40 @@
-if [ "${DISTRIBUTION}" = "zstream" ]; then
+# Zstream Job requires it's own requirements and the versions are freezed.
+if [ "${DISTRIBUTION}" = "satellite6-zstream" ]; then
     pip install -U -r requirements-freeze.txt
 else
     pip install -U -r requirements.txt docker-py pytest-xdist
 fi
+
+source ${PROVISIONING_CONFIG}
+
+# Provisioning jobs TARGET_IMAGE becomes the SOURCE_IMAGE for Tier and RHAI jobs.
+export SOURCE_IMAGE="${TARGET_IMAGE}"
+export TARGET_IMAGE=`echo ${TARGET_IMAGE} | cut -d '-' -f1-3`
+
+echo "========================================"
+echo " Remove any running instances if any of ${TARGET_IMAGE} virsh domain."
+echo "========================================"
+set +e
+ssh -o StrictHostKeyChecking=no root@"${PROVISIONING_HOST}" virsh destroy ${TARGET_IMAGE}
+ssh -o StrictHostKeyChecking=no root@"${PROVISIONING_HOST}" virsh undefine ${TARGET_IMAGE}
+ssh -o StrictHostKeyChecking=no root@"${PROVISIONING_HOST}" virsh vol-delete --pool default /var/lib/libvirt/images/${TARGET_IMAGE}.img
+set -e
+
+# Provision the instance using satellite6 base image as the source image
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@"${PROVISIONING_HOST}" \
+snap-guest -b "${SOURCE_IMAGE}" -t "${TARGET_IMAGE}" --hostname "${TARGET_IMAGE}.${VM_DOMAIN}" \
+-m "${VM_RAM}" -c "${VM_CPU}" -d "${VM_DOMAIN}" -f -n bridge="${BRIDGE}" --static-ipaddr "${IPADDR}" \
+--static-netmask "${NETMASK}" --static-gateway "${GATEWAY}"
+
+# SSH into the instance to fetch hostname and make sure it is up and running or loop 7 time
+count=1; while [ $count -le 7 ]; do echo "Trying to ssh to ${TARGET_IMAGE}.${VM_DOMAIN}"; (( count++ )); \
+sleep $count ; ssh -o StrictHostKeyChecking=no root@"${TARGET_IMAGE}.${VM_DOMAIN} hostname"  && exit; done
+
+# SELINUX fix required as after reboot the iptable information is lost. Temporary fix
+ssh -o StrictHostKeyChecking=no root@"${TARGET_IMAGE}.${VM_DOMAIN}" 'iptables -F'
+
+# Restart Satellite6 service for a clean state of the running instance.
+ssh -o StrictHostKeyChecking=no root@"${TARGET_IMAGE}.${VM_DOMAIN}" 'katello-service restart'
 
 cp ${ROBOTTELO_CONFIG} ./robottelo.properties
 
@@ -44,15 +76,6 @@ if [ "${CLEANUP_SATELLITE_ORGS}" = 'false' ]; then
 fi
 
 if [ "${ENDPOINT}" != "rhai" ]; then
-    # Reset satellite at the start of tier2, tier3, tier4 jobs
-    # if [[ "${ENDPOINT}" =~ tier[234] ]]; then
-    #    echo "Resetting Satellite and applying workaround..."
-    #    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -T root@"${SERVER_HOSTNAME}" <<-EOF
-    #		satellite-installer --reset
-    #		hammer -u admin -p changeme settings set --name=check_services_before_actions --value=false
-    #	EOF
-    # fi
-
     set +e
     # Run parallel tests
     $(which py.test) -v --junit-xml="${ENDPOINT}-parallel-results.xml" -n "${ROBOTTELO_WORKERS}" \
@@ -75,3 +98,8 @@ echo "========================================"
 echo "Hostname: ${SERVER_HOSTNAME}"
 echo "Credentials: admin/changeme"
 echo "========================================"
+echo
+echo "Delete the instance of: ${SERVER_HOSTNAME}"
+ssh -o StrictHostKeyChecking=no root@"${PROVISIONING_HOST}" virsh destroy ${TARGET_IMAGE}
+ssh -o StrictHostKeyChecking=no root@"${PROVISIONING_HOST}" virsh undefine ${TARGET_IMAGE}
+ssh -o StrictHostKeyChecking=no root@"${PROVISIONING_HOST}" virsh vol-delete --pool default /var/lib/libvirt/images/${TARGET_IMAGE}.img

--- a/scripts/satellite6-provisioning.sh
+++ b/scripts/satellite6-provisioning.sh
@@ -14,9 +14,18 @@ if [ "${DISTRIBUTION}" = 'satellite6-zstream' ]; then
     DISTRIBUTION='satellite6-downstream'
 fi
 
-fab -H "root@${PROVISIONING_HOST}" "product_install:${DISTRIBUTION},create_vm=true,sat_cdn_version=${SATELLITE_VERSION},test_in_stage=${STAGE_TEST}"
+# For example: The target_image in PROVISIONING_CONFIG file should be "qe-sat6-rhel7-base".
+BTARGET_IMAGE="${TARGET_IMAGE}"
+# Remove "-base" suffix for hostname.
+TARGET_IMAGE=`echo ${TARGET_IMAGE} | cut -d '-' -f1-3`
+export SERVER_HOSTNAME="${TARGET_IMAGE}.${VM_DOMAIN}"
+set +e
+fab -H "root@${PROVISIONING_HOST}" "vm_destroy:target_image=${TARGET_IMAGE},delete_image=true"
+set -e
+# Revert the target_image name for creating and destroying of the base-image.
+export TARGET_IMAGE="${BTARGET_IMAGE}"
 
-SERVER_HOSTNAME="${TARGET_IMAGE}.${VM_DOMAIN}"
+fab -H "root@${PROVISIONING_HOST}" "product_install:${DISTRIBUTION},create_vm=true,sat_cdn_version=${SATELLITE_VERSION},test_in_stage=${STAGE_TEST}"
 
 # Write a properties file to allow passing variables to other build steps
 echo "SERVER_HOSTNAME=${SERVER_HOSTNAME}" > build_env.properties
@@ -26,11 +35,23 @@ echo "NETMASK=${NETMASK}" >> build_env.properties
 echo "GATEWAY=${GATEWAY}" >> build_env.properties
 echo "BRIDGE=${BRIDGE}" >> build_env.properties
 echo "DISCOVERY_ISO=${DISCOVERY_ISO}" >> build_env.properties
-
 echo
 echo "========================================"
 echo "Server information"
 echo "========================================"
 echo "Hostname: ${SERVER_HOSTNAME}"
 echo "Credentials: admin/changeme"
+echo "========================================"
+echo
+echo "========================================"
+echo "Shutting down the Base instance of ${SERVER_HOSTNAME} gracefully"
+# Shutdown the Satellite6 services before shutdown.
+ssh -o StrictHostKeyChecking=no root@"${SERVER_HOSTNAME}" katello-service stop
+# Try to shutdown the Satellite6 instance gracefully and sleep for a while.
+ssh -o StrictHostKeyChecking=no root@"${PROVISIONING_HOST}" virsh shutdown ${TARGET_IMAGE}
+sleep 120
+set +e
+# Destroy the sat6 instance anyways if for some reason virsh shutdown couldn't gracefully shut it down.
+ssh -o StrictHostKeyChecking=no root@"${PROVISIONING_HOST}" virsh destroy ${TARGET_IMAGE}
+set -e
 echo "========================================"


### PR DESCRIPTION
a) This will use the target_image of the provisioning job as the
source_image for the Tier and rhai jobs.
b) Will re-provision a fresh sat6 instance each time a new Tier
job is triggered, by first destroying, undefining and deleting the
previous sat6 instance.
c) The idea is to use snapshot restore feature to do this.