### PR TITLE
Join threaded logs at the end of the build closes #306

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -65,7 +65,12 @@ if [ "${ENDPOINT}" != "rhai" ]; then
         tests/foreman/{api,cli,ui,longrun}
     set -e
 else
-    make test-foreman-${ENDPOINT} PYTEST_XDIST_NUMPROCESSES=4
+    make test-foreman-${ENDPOINT} PYTEST_XDIST_NUMPROCESSES=${ROBOTTELO_WORKERS}
+fi
+
+if [ "${ROBOTTELO_WORKERS}" -gt 0 ]; then
+    make logs-join
+    make logs-clean
 fi
 
 echo


### PR DESCRIPTION
When running with multi threads robottelo writes multiple logs `robottelo_gw1.log`... 
Calling `make logs-join` joins all the logs in `robottelo_master.log` file.

The make target `logs-join` starts with `-` which causes it to always return with code 0 even if file doesn't exist, so it avoids a broken build if a problem happens joining the logs.