### PR TITLE
Update betelgeuse jobs

### DIFF
--- a/jobs/satellite6-betelgeuse.yaml
+++ b/jobs/satellite6-betelgeuse.yaml
@@ -1,5 +1,6 @@
 - job:
     name: satellite6-betelgeuse-test-case
+    node: sesame
     scm:
         - git:
             url: https://github.com/SatelliteQE/robottelo.git
@@ -18,21 +19,21 @@
             clear: true
             nature: shell
             command:
-                !include-raw: scripts/satellite6-betelgeuse.sh
-        - shining-panda:
-            build-environment: virtualenv
-            name: betelgeuse
-            python-version: System-CPython-2.7
-            clear: false
-            nature: shell
-            command:
-                !include-raw: scripts/satellite6-betelgeuse-test-case.sh
+                !include-raw:
+                    - scripts/satellite6-betelgeuse.sh
+                    - scripts/satellite6-betelgeuse-test-case.sh
         - shell: rm .pylarion
 
 
 - job-template:
     name: satellite6-betelgeuse-test-run-{os}
     node: sesame
+    scm:
+        - git:
+            url: https://github.com/SatelliteQE/robottelo.git
+            branches:
+                - origin/master
+            skip-tag: true
     parameters:
         - string:
             name: TEST_RUN_ID
@@ -47,19 +48,19 @@
         - copyartifact:
             project: satellite6-automation-downstream-{os}-tier1
             filter: '*-results.xml'
-            which-build: workspace-latest
+            which-build: last-completed
         - copyartifact:
             project: satellite6-automation-downstream-{os}-tier2
             filter: '*-results.xml'
-            which-build: workspace-latest
+            which-build: last-completed
         - copyartifact:
             project: satellite6-automation-downstream-{os}-tier3
             filter: '*-results.xml'
-            which-build: workspace-latest
+            which-build: last-completed
         - copyartifact:
             project: satellite6-automation-downstream-{os}-tier4
             filter: '*-results.xml'
-            which-build: workspace-latest
+            which-build: last-completed
         - shining-panda:
             build-environment: virtualenv
             name: betelgeuse
@@ -67,13 +68,7 @@
             clear: true
             nature: shell
             command:
-                !include-raw-escape: scripts/satellite6-betelgeuse.sh
-        - shining-panda:
-            build-environment: virtualenv
-            name: betelgeuse
-            python-version: System-CPython-2.7
-            clear: false
-            nature: shell
-            command:
-                !include-raw-escape: scripts/satellite6-betelgeuse-test-run.sh
+                !include-raw-escape:
+                    - scripts/satellite6-betelgeuse.sh
+                    - scripts/satellite6-betelgeuse-test-run.sh
         - shell: rm .pylarion

--- a/scripts/satellite6-betelgeuse-test-case.sh
+++ b/scripts/satellite6-betelgeuse-test-case.sh
@@ -1,1 +1,1 @@
-betelgeuse -j auto test-case --path tests/foreman ${POLARION_DEFAULT_PROJECT}
+betelgeuse test-case --path tests/foreman ${POLARION_DEFAULT_PROJECT}

--- a/scripts/satellite6-betelgeuse-test-run.sh
+++ b/scripts/satellite6-betelgeuse-test-run.sh
@@ -16,10 +16,11 @@ for path in tier{1,2,3,4}-{parallel,sequential}-results.xml; do
             ;;
     esac
 
-    betelgeuse -j auto test-run \
+    betelgeuse test-run \
         --path "${path}" \
         --test-run-id "${TEST_RUN_ID} - ${tier}" \
         --test-template-id "${TEST_TEMPLATE_ID}" \
         --user ${POLARION_USER} \
+        --source-code-path tests/foreman \
         ${POLARION_DEFAULT_PROJECT}
 done

--- a/scripts/satellite6-betelgeuse.sh
+++ b/scripts/satellite6-betelgeuse.sh
@@ -1,22 +1,10 @@
 rm -rf pylarion
-git clone --depth 1 ${PYLARION_REPO_URL}
-
-# Make pylarion ready to be installed on a virtual environment
-cd pylarion
-cp setup.py setup.py.old
-head -n -3 setup.py.old > setup.py
-sed -i "s|'/etc', ||" setup.py
-sed -i "s/cachingpolicy=1/cachingpolicy=0/" src/pylarion/session.py
+git clone ${PYLARION_REPO_URL}
 
 # Install pylarion and its dependencies
+cd pylarion
+git checkout origin/satelliteqe-pylarion
 pip install -r requirements.txt
-pip install .
-cd ..
-
-# Install testimony from master
-rm -rf testimony
-git clone --depth 1 https://github.com/SatelliteQE/testimony.git
-cd testimony
 pip install .
 cd ..
 


### PR DESCRIPTION
* Install the forked Pylarion.
* Install Testimony from PyPI.
* Run in single thread mode to avoid Polarion issues.
* Pass the source code path when running betelgeuse test-run in order to make
  betelgeuse get the test IDs.
* Specify the node for the test-case job
* Pass a list of file to JJB include tags instead of repeating an entire
  builder definition.
* Change the copyartifact definition to get from the last-completed build.