### PR TITLE
Updated references to smoke tests to endtoend tests

### DIFF
--- a/jobs/satellite6-standalone-automation.yaml
+++ b/jobs/satellite6-standalone-automation.yaml
@@ -29,11 +29,11 @@
                 - 'cli'
                 - 'ui'
                 - 'rhai'
-                - 'smoke-api'
-                - 'smoke-cli'
-                - 'smoke-ui'
+                - 'endtoend-api'
+                - 'endtoend-cli'
+                - 'endtoend-ui'
                 - 'all'
-                - 'smoke-all'
+                - 'endtoend-all'
             description: |
                 Be aware that the all TEST_TYPE will last for more than 4-5 hours
         - string:


### PR DESCRIPTION
Since `smoke` tests are no longer cool and they have been renamed to `endtoend` tests, we need to update the targets that contain references to them.
Note this needs to be merged after: https://github.com/SatelliteQE/robottelo/pull/3572