### PR TITLE
Run Trigger job for Capsule Upgrade

### DIFF
--- a/scripts/satellite6-upgrade-trigger.sh
+++ b/scripts/satellite6-upgrade-trigger.sh
@@ -28,4 +28,4 @@ function export_rhev_env_var {{
 }}
 
 export_rhev_env_var
-fab -u root product_upgrade:'satellite'
+fab -u root product_upgrade:'capsule'


### PR DESCRIPTION
The one word changes the whole upgrade job to trigger capsule upgrade after finishing satellite upgrade.