### PR TITLE
Remove --boxed when calling py.test

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -90,7 +90,7 @@ if [ "${ENDPOINT}" != "rhai" ]; then
     set +e
     # Run parallel tests
     $(which py.test) -v --junit-xml="${ENDPOINT}-parallel-results.xml" -n "${ROBOTTELO_WORKERS}" \
-        --boxed -m "${ENDPOINT} and not run_in_one_thread and not stubbed" \
+        -m "${ENDPOINT} and not run_in_one_thread and not stubbed" \
         tests/foreman/{api,cli,ui,longrun}
 
     # Run sequential tests


### PR DESCRIPTION
When using --boxed pytest-xdist will run setUpClass for each test and not for
each process as was expected. Without the --boxed option pytest-xdist will run
setUpClass for each process which should decrease the time needed to run
automation.

Thank @rochacbruno for doing a good research on who the --boxed option works.

Close #324