### PR TITLE
Bump number of workers from 4 to 8.

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -517,7 +517,7 @@
             default: false
         - string:
             name: ROBOTTELO_WORKERS
-            default: '4'
+            default: '8'
             description: Number of workers to use while running robottelo test suite
     wrappers:
         - build-name:


### PR DESCRIPTION
Bump the number of threads for all parallel jobs from 4 to 8. Sequential tests
won't be affected.