### PR TITLE
Fix - escaped tilda to be evaluated on the remote side instead of local

### DIFF
--- a/scripts/satellite6-automation-foreman-debug.sh
+++ b/scripts/satellite6-automation-foreman-debug.sh
@@ -8,7 +8,7 @@ fi
 # Disable error checking, for more information check the related issue
 # http://projects.theforeman.org/issues/13442
 set +e
-ssh "root@${SERVER_HOSTNAME}" foreman-debug -g -q -d ~/foreman-debug
+ssh "root@${SERVER_HOSTNAME}" foreman-debug -g -q -d "~/foreman-debug"
 set -e
 
-scp -r "root@${SERVER_HOSTNAME}:~/foreman-debug/foreman-debug.tar.xz" .
+scp -r "root@${SERVER_HOSTNAME}:~/foreman-debug.tar.xz" .


### PR DESCRIPTION
The `~` in the previous commit wasn't escaped so it evaluated to the homedir of the local user, causing the debug file to be generated in totally different directory on the remote side.

```
18:09 $ SERVER_HOSTNAME=my.precious.com ./satellite6-automation-foreman-debug.sh
Exporting tasks, this may take a few minutes.

foreman-debug.tar.xz                                        100%  183KB 183.0KB/s   00:01
```