### PR TITLE
Added ROBOTTELO_PROPERTIES as a text field in standalone automation

### DIFF
--- a/jobs/satellite6-standalone-automation.yaml
+++ b/jobs/satellite6-standalone-automation.yaml
@@ -67,6 +67,13 @@
             default: '4'
             description: |
                 You can override this to other value of your choice.
+        - text:
+            name: ROBOTTELO_PROPERTIES
+            description: |
+                <p>You can provide robottelo.properties file content here</p>
+                <p><strong>If this parameter is not blank then SERVER_HOSTNAME,
+                SSH_USER, FOREMAN_ADMIN_USER and FOREMAN_ADMIN_PASSWORD
+                will be ignored</strong></p>
     scm:
         - git:
             url: ${ROBOTTELO_REPO}

--- a/scripts/satellite6-standalone-automation.sh
+++ b/scripts/satellite6-standalone-automation.sh
@@ -1,18 +1,22 @@
 set -o nounset
 
-if [ "${ROBOTTELO_BRANCH}" = "6.1.z" ]; then
+if [ -f "requirements-freeze.txt" ]; then
     pip install -U -r requirements-freeze.txt
 else
     pip install -U -r requirements.txt docker-py pytest-xdist
 fi
 
-cp "${ROBOTTELO_CONFIG}" ./robottelo.properties
+if [ -n "${ROBOTTELO_PROPERTIES:-}" ]; then
+    echo "${ROBOTTELO_PROPERTIES}" > ./robottelo.properties
+else
+    cp "${ROBOTTELO_CONFIG}" ./robottelo.properties
 
-sed -i "s/{server_hostname}/${SERVER_HOSTNAME}/" robottelo.properties
-sed -i "s/^ssh_username.*/ssh_username=${SSH_USER}/" robottelo.properties
+    sed -i "s/{server_hostname}/${SERVER_HOSTNAME}/" robottelo.properties
+    sed -i "s/^ssh_username.*/ssh_username=${SSH_USER}/" robottelo.properties
 
-sed -i "s/^admin_username.*/admin_username=${FOREMAN_ADMIN_USER}/" robottelo.properties
-sed -i "s/^admin_password.*/admin_password=${FOREMAN_ADMIN_PASSWORD}/" robottelo.properties
+    sed -i "s/^admin_username.*/admin_username=${FOREMAN_ADMIN_USER}/" robottelo.properties
+    sed -i "s/^admin_password.*/admin_password=${FOREMAN_ADMIN_PASSWORD}/" robottelo.properties
+fi
 
 pytest() {
     $(which py.test) -v --junit-xml=foreman-results.xml -m "${PYTEST_MARKS}" "$@"


### PR DESCRIPTION
Added **ROBOTTELO_PROPERTIES** as a text_field in standalone-automation, if provided will override the whole file.

See https://github.com/SatelliteQE/robottelo/pull/3812