### PR TITLE
Add Satellite6.3 support to satellite-installer job

### DIFF
--- a/jobs/parameters/satellite6_provisioning_parameters.yaml
+++ b/jobs/parameters/satellite6_provisioning_parameters.yaml
@@ -1,15 +1,6 @@
 - parameter:
     name: satellite6-provisioning-parameters
     parameters:
-        - string:
-            name: DOGFOOD_URL
-            description: FQDN for the Satellite containing content to install from
-        - string:
-            name: DOGFOOD_ORG
-            description: Organization to subscribe to
-        - string:
-            name: DOGFOOD_ACTIVATIONKEY
-            description: Activation Key to use when subscribing to a Satellite
         - choice:
             name: SELINUX_MODE
             choices:

--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -14,35 +14,33 @@
             name: SERVER_HOSTNAME
             description: "FQDN for your server where you want to install Satellite 6."
         - choice:
-            name: DISTRIBUTION
+            name: SATELLITE_DISTRIBUTION
             choices:
-                - DOWNSTREAM
+                - INTERNAL AK
+                - INTERNAL
+                - INTERNAL REPOFILE
                 - CDN
                 - BETA
-                - ISO
                 - UPSTREAM
+                - ISO
             description: |
                 <p>Choose the distribution type:</p>
                 <ul>
-                  <li><strong>DOWNSTREAM</strong>: Install from latest stable internal compose</li>
+                  <li><strong>INTERNALAK</strong>: Install Satellite6.3 via AK from latest stable internal compose</li>
+                  <li><strong>INTERNAL</strong>: Install Satellite6 from latest stable internal compose</li>
+                  <li><strong>INTERNALREPOFILE</strong>: Install Satellite6.3 via REPOFILE from latest stable internal compose</li>
                   <li><strong>CDN</strong>: Install from CDN</li>
                   <li><strong>BETA</strong>: Install from CDN, using the beta repository</li>
-                  <li><strong>ISO</strong>: Install from an ISO image from latest stable internal compose</li>
-                  <li><strong>UPSTREAM</strong>: Install from latest community build</li>
+                  <li><strong>UPSTREAM</strong>: Install from latest community nightly build</li>
                 </ul>
         - choice:
             name: SATELLITE_VERSION
             choices:
+                - '6.3'
                 - '6.2'
                 - '6.1'
                 - '6.0'
             description: Make sure to select the right Satellite version you want to install, otherwise the job can fail.
-        - choice:
-            name: SATELLITE_RELEASE
-            choices:
-                - 'GA'
-                - 'BETA'
-            description: Make sure to select the right Satellite release you want to install, otherwise the job can fail.
         - choice:
             name: SELINUX_MODE
             choices:

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -3,12 +3,19 @@ pip install -U -r requirements.txt
 # Figure out what version of RHEL the server uses
 export OS_VERSION=$(fab -H root@${SERVER_HOSTNAME} distro_info | grep "rhel [[:digit:]]" | cut -d ' ' -f 2)
 
-
 source ${INSTALL_CONFIG}
 source ${PROXY_CONFIG}
 # OS_VERSION needs to be defined before sourcing SATELLITE6_REPOS_URLS
 source ${SATELLITE6_REPOS_URLS}
 source ${SUBSCRIPTION_CONFIG}
+
+# Populate DOGFOOD_AACTIVATIONKEY ENV_VAR depending upon the OS_VERSION
+if [ "${OS_VERSION}" = '7' ]; then
+    export DOGFOOD_ACTIVATIONKEY="${DOGFOOD_RHEL7_AK}"
+elif [ "${OS_VERSION}" = '6' ]; then
+    export DOGFOOD_ACTIVATIONKEY="${DOGFOOD_RHEL6_AK}"
+fi
+
 if [ "$STAGE_TEST" = 'false' ]; then
     source ${SUBSCRIPTION_CONFIG}
 else
@@ -23,9 +30,23 @@ if [ ${PARTITION_DISK} = "true" ]; then
     fab -H root@${SERVER_HOSTNAME} partition_disk
 fi
 
+# Assign DISTRIBUTION to trigger things appropriately from automation-tools.
+if [ "${SATELLITE_DISTRIBUTION}" = 'INTERNAL' ]; then
+    export DISTRIBUTION="satellite6-downstream"
+elif [ "${SATELLITE_DISTRIBUTION}" = 'GA' ]; then
+    export DISTRIBUTION="satellite6-cdn"
+elif [ "${SATELLITE_DISTRIBUTION}" = 'BETA' ]; then
+    export DISTRIBUTION="satellite6-beta"
+elif [ "${SATELLITE_DISTRIBUTION}" = 'UPSTREAM' ]; then
+    export DISTRIBUTION="satellite6-upstream"
+elif [ "${SATELLITE_DISTRIBUTION}" = 'INTERNAL REPOFILE' ]; then
+    export DISTRIBUTION="satellite6-repofile"
+elif [ "${SATELLITE_DISTRIBUTION}" = 'INTERNAL AK' ]; then
+    export DISTRIBUTION="satellite6-activationkey"
+fi
 
 # ISOs require a specific URL
-if [ ${DISTRIBUTION} = "ISO" ]; then
+if [ ${SATELLITE_DISTRIBUTION} = "ISO" ]; then
     # If user provided custom baseurl, use it otherwise use the default
     if [ ! -z "$SATELLITE6_CUSTOM_BASEURL" ]; then
         export ISO_URL="${SATELLITE6_CUSTOM_BASEURL}"
@@ -35,7 +56,7 @@ if [ ${DISTRIBUTION} = "ISO" ]; then
 fi
 
 # This is only used for downstream builds
-if [ ${DISTRIBUTION} = "DOWNSTREAM" ]; then
+if [ ${SATELLITE_DISTRIBUTION} = "INTERNAL" ]; then
     # If user provided custom baseurl, use it otherwise use the default
     if [ ! -z "$SATELLITE6_CUSTOM_BASEURL" ]; then
         export BASE_URL="${SATELLITE6_CUSTOM_BASEURL}"


### PR DESCRIPTION
a) Now satellite-installer job also uses INTERNAL, INTERNAL AK and
   INTERNAL REPOFILE

b) For Satellite6-automation, DOGFOOD_ACTIVATIONKEY and
   REPO_FILE_URL are now automatically calculated in the
   Subscription config-file depending upon the DISTRO variable, for
   installations via jenkins.

c) For Satellite-installer, as the DISTRO value is not populated,
   DOGFOOD_ACTIVATIONKEY and REPO_FILE_URL  is calculated depending
   upon OS_VERSION available in installer.sh script used by
   satellite-installer job.

d) Now DOGFOOD ENV_VAR and REPO_FILE_URL are specified in the config-file,
   Subscription Config File.