### PR TITLE
Run polarion test-run, t4 tests and collect automation-report for all the sat6 jobs.

### DIFF
--- a/jobs/parameters/satellite6_provisioning_parameters.yaml
+++ b/jobs/parameters/satellite6_provisioning_parameters.yaml
@@ -18,7 +18,9 @@
             description: Number of workers to use while running robottelo test suite
         - string:
             name: BUILD_LABEL
-            description: Specify the build label of the Satellite
+            description: |
+                Specify the build label of the Satellite. Example Sat6.3.0-1.0
+                Which is Sat6.y.z-SNAP.COMPOSE
         - bool:
             name: STAGE_TEST
             default: false

--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -197,14 +197,9 @@
                 DISTRO={os}
     builders:
         - satellite6-automation-builders
-        - conditional-step:
-            condition-kind: regex-match
-            regex: (6\.[23])
-            label: ${{ENV,var="SATELLITE_VERSION"}}
-            steps:
-                - trigger-builds:
-                    - project: 'automation-{satellite_version}-tier4-{os}'
-                      current-parameters: true
+        - trigger-builds:
+            - project: 'automation-{satellite_version}-tier4-{os}'
+              current-parameters: true
 
     publishers:
         - satellite6-automation-publishers
@@ -288,16 +283,11 @@
                 - trigger-builds:
                     - project: 'automation-{satellite_version}-rhai-{os}'
                       current-parameters: true
-        - conditional-step:
-            condition-kind: regex-match
-            regex: (6\.[23])
-            label: ${{ENV,var="SATELLITE_VERSION"}}
-            steps:
-                - trigger-builds:
-                    - project: 'polarion-test-run-{satellite_version}-{os}'
-                      predefined-parameters: |
-                          TEST_RUN_ID=$BUILD_LABEL {os}
-                          POLARION_RELEASE=$POLARION_RELEASE
+        - trigger-builds:
+            - project: 'polarion-test-run-{satellite_version}-{os}'
+              predefined-parameters: |
+                  TEST_RUN_ID=$BUILD_LABEL {os}
+                  POLARION_RELEASE=$POLARION_RELEASE
     publishers:
         - satellite6-automation-publishers
         - satellite6-automation-foreman-debug
@@ -318,7 +308,7 @@
     builders:
         - shell: rm -f *.xml
         - copyartifact:
-            project: 'automation-{satellite_version}-tier4-{os}'
+            project: 'automation-{satellite_version}-tier1-{os}'
             filter: '*-results.xml'
             which-build: last-successful
         - copyartifact:
@@ -555,7 +545,7 @@
         - timed: 'H 19 * * *'
     builders:
         - shell:
-            echo "BUILD_LABEL=Upstream $(date +%Y-%m-%d)" > properties.txt
+            echo "BUILD_LABEL=Upstream Nightly $(date +%Y-%m-%d)" > properties.txt
         - inject:
             properties-file: properties.txt
         - trigger-builds:

--- a/scripts/satellite6-provisioning.sh
+++ b/scripts/satellite6-provisioning.sh
@@ -56,7 +56,12 @@ if [ "${SATELLITE_VERSION}" = "6.3" ]; then
 else
     ZRELEASE='z'
 fi
-echo "POLARION_RELEASE='Satellite ${SATELLITE_VERSION}.${ZRELEASE}'" >> build_env.properties
+
+if [ "${SATELLITE_VERSION}" = "nightly" ]; then
+    echo "POLARION_RELEASE='Upstream Nightly'" >> build_env.properties
+elif [ "${SATELLITE_VERSION}" != "nightly" ]; then
+    echo "POLARION_RELEASE='Satellite ${SATELLITE_VERSION}.${ZRELEASE}'" >> build_env.properties
+fi
 
 # Run installation after writing the build_env.properties to make sure the
 # values are available for the post build actions, specially the foreman-debug


### PR DESCRIPTION
a) Tier4 tests will not run for all satellite jobs.

b) report-automation-results will also run for sat61 as they get
   triggered via t4 tests, which is now enabled for all.

c) Fix a typo in report-automation-results which was copying
   artifacts of t4 instead of t1

d) Added  a build_label parameter example.