### PR TITLE
Use config files out of internal gitlab

### DIFF
--- a/jobs/satellite5-installer.yaml
+++ b/jobs/satellite5-installer.yaml
@@ -66,10 +66,8 @@
         - build-user-vars
         - config-file-provider:
             files:
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1430487341650
-                  variable: SAT5_CERT_CONFIG
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1426679847040
-                  variable: SUBSCRIPTION_CONFIG
+                - file-id: bc5f0cbc-616f-46de-bdfe-2e024e84fcbf
+                  variable: CONFIG_FILES
     builders:
         - shining-panda:
             build-environment: virtualenv

--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -41,18 +41,8 @@
         - default-wrappers
         - config-file-provider:
             files:
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1421863970654
-                  variable: FAKE_CERT_CONFIG
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1426617852908
-                  variable: PROXY_CONFIG
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1421176025444
-                  variable: PROVISIONING_CONFIG
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1426679847040
-                  variable: SUBSCRIPTION_CONFIG
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1439493457257
-                  variable: STAGE_CONFIG
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1440792796745
-                  variable: INSTALL_CONFIG
+                - file-id: bc5f0cbc-616f-46de-bdfe-2e024e84fcbf
+                  variable: CONFIG_FILES
         - inject:
             properties-content: |
                 DISTRO={os}
@@ -370,12 +360,8 @@
         - default-wrappers
         - config-file-provider:
             files:
-                - file-id: 273ccbb1-70fa-40cc-8cb7-ec5f284631b0
-                  variable: RHEV_CONFIG
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1430942714372
-                  variable: SATELLITE6_REPOS_URLS
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1426679847040
-                  variable: SUBSCRIPTION_CONFIG
+                - file-id: bc5f0cbc-616f-46de-bdfe-2e024e84fcbf
+                  variable: CONFIG_FILES
         - build-name:
             name: '#${{BUILD_NUMBER}} Upgrade_{os}_from_${{FROM_VERSION}}_to_${{TO_VERSION}}'
     builders:
@@ -436,8 +422,8 @@
     wrappers:
         - config-file-provider:
             files:
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1430942714372
-                  variable: SATELLITE6_REPOS_URLS
+                - file-id: bc5f0cbc-616f-46de-bdfe-2e024e84fcbf
+                  variable: CONFIG_FILES
         - inject:
             properties-content: |
                 SATELLITE_VERSION={satellite_version}
@@ -445,7 +431,8 @@
             name: '#${{BUILD_NUMBER}} ${{ENV,var="BUILD_LABEL"}}'
     builders:
         - shell: |
-            source ${{SATELLITE6_REPOS_URLS}}
+            source ${{CONFIG_FILES}}
+            source config/sat6_repos_urls.conf
             echo "RHEL6_SATELLITE_URL=${{RHEL6_SATELLITE_URL:-${{SATELLITE6_RHEL6}}}}" > properties.txt
             echo "RHEL6_CAPSULE_URL=${{RHEL6_CAPSULE_URL:-${{CAPSULE_RHEL6}}}}" >> properties.txt
             echo "RHEL6_TOOLS_URL=${{RHEL6_TOOLS_URL:-${{TOOLS_RHEL6}}}}" >> properties.txt

--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -126,18 +126,8 @@
         - build-user-vars
         - config-file-provider:
             files:
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1421863970654
-                  variable: FAKE_CERT_CONFIG
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1426617852908
-                  variable: PROXY_CONFIG
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1430942714372
-                  variable: SATELLITE6_REPOS_URLS
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1426679847040
-                  variable: SUBSCRIPTION_CONFIG
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1439493457257
-                  variable: STAGE_CONFIG
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1440792796745
-                  variable: INSTALL_CONFIG
+                - file-id: bc5f0cbc-616f-46de-bdfe-2e024e84fcbf
+                  variable: CONFIG_FILES
         - default-wrappers
     builders:
         - shining-panda:

--- a/jobs/satellite6-manifest-downloader.yaml
+++ b/jobs/satellite6-manifest-downloader.yaml
@@ -16,10 +16,8 @@
         - default-wrappers
         - config-file-provider:
             files:
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1421863970654
-                  variable: FAKE_CERT_CONFIG
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1426679847040
-                  variable: SUBSCRIPTION_CONFIG
+                - file-id: bc5f0cbc-616f-46de-bdfe-2e024e84fcbf
+                  variable: CONFIG_FILES
     builders:
         - shining-panda:
             build-environment: virtualenv

--- a/jobs/satellite6-upgrader.yaml
+++ b/jobs/satellite6-upgrader.yaml
@@ -71,12 +71,8 @@
         - build-user-vars
         - config-file-provider:
             files:
-                - file-id: 273ccbb1-70fa-40cc-8cb7-ec5f284631b0
-                  variable: RHEV_CONFIG
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1430942714372
-                  variable: SATELLITE6_REPOS_URLS
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1426679847040
-                  variable: SUBSCRIPTION_CONFIG
+                - file-id: bc5f0cbc-616f-46de-bdfe-2e024e84fcbf
+                  variable: CONFIG_FILES
         - default-wrappers
     builders:
           - shining-panda:

--- a/jobs/wrappers/satellite6_automation_wrappers.yaml
+++ b/jobs/wrappers/satellite6_automation_wrappers.yaml
@@ -3,10 +3,8 @@
     wrappers:
         - config-file-provider:
             files:
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1431607187795
-                  variable: ROBOTTELO_CONFIG
-                - file-id: org.jenkinsci.plugins.configfiles.custom.CustomConfig1421176025444
-                  variable: PROVISIONING_CONFIG
+                - file-id: bc5f0cbc-616f-46de-bdfe-2e024e84fcbf
+                  variable: CONFIG_FILES
         - workspace-cleanup:
             include:
                 - 'robottelo*.log'

--- a/scripts/installer5.sh
+++ b/scripts/installer5.sh
@@ -1,7 +1,8 @@
 pip install -U -r requirements.txt
 
-source ${SUBSCRIPTION_CONFIG}
-source ${SAT5_CERT_CONFIG}
+source ${CONFIG_FILES}
+source config/subscription_config.conf
+source config/sat5_activation_cert.conf
 
 if [ ${FIX_HOSTNAME} = "true" ]; then
     fab -H root@${SERVER_HOSTNAME} fix_hostname

--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -39,15 +39,16 @@ function setup_instance () {
     ssh -o StrictHostKeyChecking=no root@"${TARGET_IMAGE}.${VM_DOMAIN}" 'katello-service restart'
 }
 
-source ${PROVISIONING_CONFIG}
+source ${CONFIG_FILES}
+source config/provisioning_environment.conf
 # Provisioning jobs TARGET_IMAGE becomes the SOURCE_IMAGE for Tier and RHAI jobs.
 export SOURCE_IMAGE="${TARGET_IMAGE}"
-export TARGET_IMAGE=`echo ${TARGET_IMAGE} | cut -d '-' -f1-3`
+export TARGET_IMAGE="${TARGET_IMAGE%%-base}"
 
 remove_instance
 setup_instance
 
-cp ${ROBOTTELO_CONFIG} ./robottelo.properties
+cp config/robottelo.properties ./robottelo.properties
 
 sed -i "s/{server_hostname}/${SERVER_HOSTNAME}/" robottelo.properties
 sed -i "s|# screenshots_path=.*|screenshots_path=$(pwd)/screenshots|" robottelo.properties

--- a/scripts/satellite6-manifest-downloader.sh
+++ b/scripts/satellite6-manifest-downloader.sh
@@ -1,4 +1,5 @@
 pip install -r requirements.txt
-source ${FAKE_CERT_CONFIG}
-source ${SUBSCRIPTION_CONFIG}
+source ${CONFIG_FILES}
+source config/fake_manifest.conf
+source config/subscription_config.conf
 fab -H "root@${MANIFEST_SERVER_HOSTNAME}" relink_manifest

--- a/scripts/satellite6-standalone-automation.sh
+++ b/scripts/satellite6-standalone-automation.sh
@@ -9,7 +9,8 @@ fi
 if [ -n "${ROBOTTELO_PROPERTIES:-}" ]; then
     echo "${ROBOTTELO_PROPERTIES}" > ./robottelo.properties
 else
-    cp "${ROBOTTELO_CONFIG}" ./robottelo.properties
+    source ${CONFIG_FILES}
+    cp config/robottelo.properties ./robottelo.properties
 
     sed -i "s/{server_hostname}/${SERVER_HOSTNAME}/" robottelo.properties
     sed -i "s/^ssh_username.*/ssh_username=${SSH_USER}/" robottelo.properties

--- a/scripts/satellite6-upgrade-trigger.sh
+++ b/scripts/satellite6-upgrade-trigger.sh
@@ -3,9 +3,11 @@
 export OS="{os}"
 
 pip install -r requirements.txt
-source "${{RHEV_CONFIG}}"
-source "${{SATELLITE6_REPOS_URLS}}"
-source "${{SUBSCRIPTION_CONFIG}}"
+source "${{CONFIG_FILES}}"
+source config/rhev.conf
+source config/sat6_repos_urls.conf
+source config/subscription_config.conf
+
 
 function export_rhev_env_var {{
     if [ "${{OS}}" = 'rhel6' ]; then

--- a/scripts/satellite6_upgrader.sh
+++ b/scripts/satellite6_upgrader.sh
@@ -7,12 +7,13 @@ elif [ "${OS}" = 'rhel6' ]; then
     export OS_VERSION='6'
 fi
 
+source ${CONFIG_FILES}
 # Source the Variables from files
 if [ -z "${SATELLITE_HOSTNAME}" ]; then
-    source "${RHEV_CONFIG}"
+    source config/rhev.conf
 fi
-source "${SATELLITE6_REPOS_URLS}"
-source "${SUBSCRIPTION_CONFIG}"
+source config/sat6_repos_urls.conf
+source config/subscription_config.conf
 
 # Set Capsule URL as per OS
 if [ "${OS}" = 'rhel7' ]; then


### PR DESCRIPTION
Use config files out of internal gitlab
- use gitlab config files instead of jenkins cfgs
- fix subscription config being sourced twice
- simplify vars assigments in satellite6-provisioning.sh

(Implements #368)