### PR TITLE
Email status when a system fails to provision.

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -75,6 +75,13 @@
                 ROBOTTELO_WORKERS=${{ROBOTTELO_WORKERS}}
                 POLARION_RELEASE=${{POLARION_RELEASE}}
     publishers:
+        - email-ext:
+            recipients: ${{QE_EMAIL_LIST}}
+            success: false
+            failure: true
+            subject: 'Provisioning of Satellite {satellite_version} {os} Job has failed'
+            body: |
+                This build ${{BUILD_URL}} has failed, may need to fix and re-trigger.
         - satellite6-automation-foreman-debug
         - satellite6-automation-archiver
 


### PR DESCRIPTION
Whenever a provisioning job fails a mail will be sent to
katello QA mailing list.