### PR TITLE
Add a job to do quick libvirt based image provisioning.

### DIFF
--- a/jobs/satellite6-libvirt-install.yaml
+++ b/jobs/satellite6-libvirt-install.yaml
@@ -1,0 +1,74 @@
+- job:
+    name: 'satellite6-libvirt-install'
+    description: |
+        Quickly up an instance using VLANs for feature and Bug testing. We could use the two new physical hardware which were
+        recently procured. This would help fully automate sat6 installation to do Libvirt, RHEVM and Openstack CR Testing.
+    node: sesame
+    parameters:
+        - choice:
+            name: SERVER_ID
+            choices:
+                - 'testing-rhel7'
+                - 'testing-rhel6'
+        - choice:
+            name: SATELLITE_DISTRIBUTION
+            choices:
+                - 'INTERNAL AK'
+                - 'INTERNAL'
+                - 'INTERNAL REPOFILE'
+                - 'GA'
+        - choice:
+            name: SAT_VERSION
+            choices:
+                - '6.3'
+                - '6.2'
+                - '6.1'
+                - '6.0'
+        - choice:
+            name: DISTRO
+            choices:
+                - 'rhel7'
+                - 'rhel6'
+        - string:
+            name: BASE_URL
+            description: Required when Satellite distribution is INTERNAL
+        - choice:
+            name: SELINUX_MODE
+            choices:
+                - 'enforcing'
+                - 'permissive'
+        - choice:
+            name: PROXY_MODE
+            choices:
+                - 'authenticated'
+                - 'non-authenticated'
+                - 'no-proxy'
+        - bool:
+            name: STAGE_TEST
+            default: false
+            description: |
+                Points to RHSM stage for stage installation test. Used only
+                in CDN provisioning.
+    scm:
+        - git:
+            url: https://github.com/SatelliteQE/automation-tools.git
+            branches:
+                - origin/master
+            skip-tag: true
+    wrappers:
+        - default-wrappers
+        - config-file-provider:
+            files:
+                - file-id: bc5f0cbc-616f-46de-bdfe-2e024e84fcbf
+                  variable: CONFIG_FILES
+    builders:
+        - shining-panda:
+            build-environment: virtualenv
+            python-version: System-CPython-2.7
+            clear: true
+            nature: shell
+            command:
+                !include-raw:
+                    - 'pip-install-pycurl.sh'
+                    - 'satellite6-libvirt-install.sh'
+

--- a/scripts/satellite6-libvirt-install.sh
+++ b/scripts/satellite6-libvirt-install.sh
@@ -1,0 +1,49 @@
+pip install -r requirements.txt
+
+source ${CONFIG_FILES}
+source config/fake_manifest.conf
+source config/installation_environment.conf
+source config/provision_libvirt_install.conf
+source config/proxy_config_environment.conf
+source config/subscription_config.conf
+if [ "${STAGE_TEST}" = 'true' ]; then
+    source config/stage_environment.conf
+fi
+
+# For Example: The TARGET_IMAGE in provision_libvirt_install.conf should be "qe-testing-rhel7".
+export TARGET_IMAGE
+set +e
+fab -H "root@${PROVISIONING_HOST}" "vm_destroy:target_image=${TARGET_IMAGE},delete_image=true"
+set -e
+
+# Assign DISTRIBUTION to trigger things appropriately from automation-tools.
+if [ "${SATELLITE_DISTRIBUTION}" = 'INTERNAL' ]; then
+    export DISTRIBUTION="satellite6-downstream"
+elif [ "${SATELLITE_DISTRIBUTION}" = 'GA' ]; then
+    export DISTRIBUTION="satellite6-cdn"
+elif [ "${SATELLITE_DISTRIBUTION}" = 'INTERNAL REPOFILE' ]; then
+    export DISTRIBUTION="satellite6-repofile"
+elif [ "${SATELLITE_DISTRIBUTION}" = 'INTERNAL AK' ]; then
+    export DISTRIBUTION="satellite6-activationkey"
+fi
+
+# Write a properties file to allow passing variables to other build steps
+echo "SERVER_HOSTNAME=${SERVER_HOSTNAME}" > build_env.properties
+echo "TOOLS_REPO=${TOOLS_URL}" >> build_env.properties
+echo "SUBNET=${SUBNET}" >> build_env.properties
+echo "NETMASK=${NETMASK}" >> build_env.properties
+echo "GATEWAY=${GATEWAY}" >> build_env.properties
+echo "BRIDGE=${BRIDGE}" >> build_env.properties
+
+# Run installation after writing the build_env.properties to make sure the
+# values are available for the post build actions, specially the foreman-debug
+# capturing.
+fab -H "root@${PROVISIONING_HOST}" "product_install:${DISTRIBUTION},create_vm=true,sat_cdn_version=${SAT_VERSION},test_in_stage=${STAGE_TEST}"
+
+echo
+echo "========================================"
+echo "Server information"
+echo "========================================"
+echo "Hostname: ${SERVER_HOSTNAME}"
+echo "Credentials: admin/changeme"
+echo "========================================"


### PR DESCRIPTION
a) This would help do Compute Resource Testing, UEFI, IPv6 and
   Discovery Testing, by quickly setting up a sat6 setup.
b) This would use the existing os images which is used for
   robottelo provisioning jobs.