### PR TITLE
add no max lines limit for foreman-debug

### DIFF
--- a/scripts/satellite6-foreman-debug.sh
+++ b/scripts/satellite6-foreman-debug.sh
@@ -6,6 +6,6 @@ fi
 # Disable error checking, for more information check the related issue
 # http://projects.theforeman.org/issues/13442
 set +e
-ssh -o StrictHostKeyChecking=no "root@${SERVER_HOSTNAME}" foreman-debug -g -q -d "~/foreman-debug"
+ssh -o StrictHostKeyChecking=no "root@${SERVER_HOSTNAME}" foreman-debug -g -m 0 -q -d "~/foreman-debug"
 set -e
 scp -o StrictHostKeyChecking=no -r "root@${SERVER_HOSTNAME}:~/foreman-debug.tar.xz" .


### PR DESCRIPTION
without the ```-m``` parameter, the foreman-debug only takes last 5000 lines from each file