### PR TITLE
Use new XUNIT Importer for Polarion Test Runs.

### DIFF
--- a/scripts/satellite6-betelgeuse-test-run.sh
+++ b/scripts/satellite6-betelgeuse-test-run.sh
@@ -1,31 +1,3 @@
-rm -rf pylarion
-git clone ${PYLARION_REPO_URL}
-
-# Install pylarion and its dependencies
-cd pylarion
-git checkout origin/satelliteqe-pylarion
-pip install -r requirements.txt
-pip install .
-cd ..
-
-rm -rf betelgeuse
-git clone https://github.com/SatelliteQE/betelgeuse.git
-cd betelgeuse
-git checkout xml-test-case
-pip install -r requirements.txt
-pip install .
-cd ..
-
-cat > .pylarion <<EOF
-[webservice]
-url=${POLARION_URL}
-user=${POLARION_USER}
-password=${POLARION_PASSWORD}
-default_project=${POLARION_DEFAULT_PROJECT}
-svn_repo=${POLARION_SVN_REPO}
-use_logstash=false
-EOF
-
 TEST_TEMPLATE_ID="Empty"
 
 # Create a new iteration for the current run
@@ -43,29 +15,29 @@ SANITIZED_ITERATION_ID="$(echo ${TEST_RUN_ID} | sed 's|\.|_|g' | sed 's| |_|g')"
 # Prepare the XML files
 for tier in $(seq 1 4)
 do
-  for run in parallel sequential
-  do
-    betelgeuse --token-prefix="@" xml-test-run \
-        --custom-fields="isautomated=true" \
-        --custom-fields="arch=x8664" \
-        --custom-fields="variant=server" \
-        --custom-fields="plannedin=${SANITIZED_ITERATION_ID}" \
-        --response-property="${POLARION_SELECTOR}" \
-        --test-run-id "${TEST_RUN_ID} - ${run} - Tier ${tier}" \
-        ./tier${tier}-${run}-results.xml \
-        tests/foreman \
-        "${POLARION_USER}" \
-        "${POLARION_DEFAULT_PROJECT}" \
-        polarion-tier${tier}-${run}-results.xml
-    curl -k -u ${POLARION_USER}:${POLARION_PASSWORD} \
-    -X POST \
-    -F file=@polarion-tier${tier}-${run}-results.xml \
-    "${POLARION_URL}import/xunit"
-  done
+   for run in parallel sequential
+   do
+       betelgeuse --token-prefix="@" xml-test-run \
+           --custom-fields="isautomated=true" \
+           --custom-fields="arch=x8664" \
+           --custom-fields="variant=server" \
+           --custom-fields="plannedin=${SANITIZED_ITERATION_ID}" \
+           --response-property="${POLARION_SELECTOR}" \
+           --test-run-id "${TEST_RUN_ID} - ${run} - Tier ${tier}" \
+           ./tier${tier}-${run}-results.xml \
+           tests/foreman \
+           "${POLARION_USER}" \
+           "${POLARION_DEFAULT_PROJECT}" \
+           polarion-tier${tier}-${run}-results.xml
+       curl -k -u ${POLARION_USER}:${POLARION_PASSWORD} \
+           -X POST \
+           -F file=@polarion-tier${tier}-${run}-results.xml \
+           "${POLARION_URL}import/xunit"
+   done
 done
 
 # Mark the iteration done
 betelgeuse test-plan \
-    --name "${TEST_RUN_ID}" \
-    --custom-fields status=done \
-    "${POLARION_DEFAULT_PROJECT}"
+     --name "${TEST_RUN_ID}" \
+     --custom-fields status=done \
+     "${POLARION_DEFAULT_PROJECT}"

--- a/scripts/satellite6-betelgeuse-test-run.sh
+++ b/scripts/satellite6-betelgeuse-test-run.sh
@@ -1,3 +1,31 @@
+rm -rf pylarion
+git clone ${PYLARION_REPO_URL}
+
+# Install pylarion and its dependencies
+cd pylarion
+git checkout origin/satelliteqe-pylarion
+pip install -r requirements.txt
+pip install .
+cd ..
+
+rm -rf betelgeuse
+git clone https://github.com/SatelliteQE/betelgeuse.git
+cd betelgeuse
+git checkout xml-test-case
+pip install -r requirements.txt
+pip install .
+cd ..
+
+cat > .pylarion <<EOF
+[webservice]
+url=${POLARION_URL}
+user=${POLARION_USER}
+password=${POLARION_PASSWORD}
+default_project=${POLARION_DEFAULT_PROJECT}
+svn_repo=${POLARION_SVN_REPO}
+use_logstash=false
+EOF
+
 TEST_TEMPLATE_ID="Empty"
 
 # Create a new iteration for the current run
@@ -9,42 +37,31 @@ else
         --plan-type iteration "${POLARION_DEFAULT_PROJECT}"
 fi
 
-TEST_PLAN_ID="$(python - <<END
-import re
-import os
-from betelgeuse import INVALID_CHARS_REGEX
-plan_id = re.sub(INVALID_CHARS_REGEX, '_', os.environ['TEST_RUN_ID']).replace(' ', '_')
-print plan_id
-END
-)"
+POLARION_SELECTOR="name=Satellite 6"
+SANITIZED_ITERATION_ID="$(echo ${TEST_RUN_ID} | sed 's|\.|_|g' | sed 's| |_|g')"
 
-for path in tier{1,2,3,4}-{parallel,sequential}-results.xml; do
-    case "$path" in
-        tier1*)
-            tier="Tier 1"
-            ;;
-        tier2*)
-            tier="Tier 2"
-            ;;
-        tier3*)
-            tier="Tier 3"
-            ;;
-        tier4*)
-            tier="Tier 4"
-            ;;
-    esac
-
-    betelgeuse --token-prefix "@" test-run \
-        --path "${path}" \
-        --test-run-id "${TEST_RUN_ID} - ${tier}" \
-        --test-template-id "${TEST_TEMPLATE_ID}" \
-        --user "${POLARION_USER}" \
-        --source-code-path tests/foreman \
-        --custom-fields isautomated=True \
-        --custom-fields arch=x8664 \
-        --custom-fields variant=server \
-        --custom-fields plannedin="${TEST_PLAN_ID}" \
-        "${POLARION_DEFAULT_PROJECT}"
+# Prepare the XML files
+for tier in $(seq 1 4)
+do
+  for run in parallel sequential
+  do
+    betelgeuse --token-prefix="@" xml-test-run \
+        --custom-fields="isautomated=true" \
+        --custom-fields="arch=x8664" \
+        --custom-fields="variant=server" \
+        --custom-fields="plannedin=${SANITIZED_ITERATION_ID}" \
+        --response-property="${POLARION_SELECTOR}" \
+        --test-run-id "${TEST_RUN_ID} - ${run} - Tier ${tier}" \
+        ./tier${tier}-${run}-results.xml \
+        tests/foreman \
+        "${POLARION_USER}" \
+        "${POLARION_DEFAULT_PROJECT}" \
+        polarion-tier${tier}-${run}-results.xml
+    curl -k -u ${POLARION_USER}:${POLARION_PASSWORD} \
+    -X POST \
+    -F file=@polarion-tier${tier}-${run}-results.xml \
+    "${POLARION_URL}import/xunit"
+  done
 done
 
 # Mark the iteration done


### PR DESCRIPTION
We can now use the new XUNIT Importer to populate Test Runs in
Polarion. Right now this PR uses code from a branch in Betelgeuse, but
once the changes from this branch are merged into master we should
update this PR to make sure that we use a published version of
Betelgeuse (instead of using a checkout).