### PR TITLE
Add support to send mails on job failures.

### DIFF
--- a/jobs/publishers/satellite6_automation_mails.yaml
+++ b/jobs/publishers/satellite6_automation_mails.yaml
@@ -1,0 +1,11 @@
+- publisher:
+    name: satellite6-automation-mails
+    publishers:
+        - email-ext:
+            recipients: ${{QE_EMAIL_LIST}}
+            success: false
+            failure: true
+            subject: 'The Build Number ${{BUILD_NUMBER}} of JOB ${{JOB_NAME}} has failed.'
+            body: |
+                This build ${{BUILD_URL}} has failed, may need to fix and re-trigger.
+

--- a/jobs/robottelo-ci-update-jobs.yaml
+++ b/jobs/robottelo-ci-update-jobs.yaml
@@ -22,3 +22,5 @@
             nature: shell
             command:
                 !include-raw: scripts/robottelo-ci-update-jobs.sh
+    publishers:
+        - satellite6-automation-mails

--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -76,13 +76,7 @@
                 ROBOTTELO_WORKERS=${{ROBOTTELO_WORKERS}}
                 POLARION_RELEASE=${{POLARION_RELEASE}}
     publishers:
-        - email-ext:
-            recipients: ${{QE_EMAIL_LIST}}
-            success: false
-            failure: true
-            subject: 'Provisioning of Satellite {satellite_version} {os} Job has failed'
-            body: |
-                This build ${{BUILD_URL}} has failed, may need to fix and re-trigger.
+        - satellite6-automation-mails
         - satellite6-automation-archiver
 
 - job-template:

--- a/jobs/satellite6-manifest-downloader.yaml
+++ b/jobs/satellite6-manifest-downloader.yaml
@@ -28,3 +28,5 @@
                 !include-raw:
                     - 'pip-install-pycurl.sh'
                     - 'satellite6-manifest-downloader.sh'
+    publishers:
+        - satellite6-automation-mails


### PR DESCRIPTION
a) The mail will be sent to QE_EMAIL_LIST which is katello-qa-list.
b) This has been configured for ci-update-jobs, provisioning jobs and the
   manifest-downloader job.