### PR TITLE
Few fixes related to jobs libvirt_install and satellite6-populate

### DIFF
--- a/scripts/satellite6-configure.sh
+++ b/scripts/satellite6-configure.sh
@@ -20,6 +20,9 @@ echo
 cp ${PWD}/scripts/satellite6-populate-template.sh satellite6-populate.sh
 chmod 755 satellite6-populate.sh
 
+# Populates the HTTP Server information.
+sed -i "s|HTTP_SERVER_NAME=.*|HTTP_SERVER_NAME=${HTTP_SERVER_NAME}|" satellite6-populate.sh
+
 # Populates the Compute Resource Information.
 
 # Populate the Libvirt CR Info

--- a/scripts/satellite6-libvirt-install.sh
+++ b/scripts/satellite6-libvirt-install.sh
@@ -47,13 +47,16 @@ echo "Hostname: ${SERVER_HOSTNAME}"
 echo "Credentials: admin/changeme"
 echo "========================================"
 
+# Download the Satellite6 Configure Template.
+wget ${HTTP_SERVER_HOSTNAME}/pub/satellite6-populate-template.sh
+
 echo
 echo "============================================="
 echo "Populating template to configure Satellite6 "
 echo "============================================="
 echo
 
-cp $(pwd)/scripts/satellite6-populate-template.sh satellite6-populate.sh
+cp satellite6-populate-template.sh satellite6-populate.sh
 chmod 755 satellite6-populate.sh
 
 # Populates the Compute Resource Information

--- a/scripts/satellite6-populate-template.sh
+++ b/scripts/satellite6-populate-template.sh
@@ -6,11 +6,11 @@ ADMIN_PASSWORD="changeme"
 # The below values get populated from the compute_resources.conf file.
 # Compute Resource Variables.
 COMPUTE_RESOURCE_NAME_LIBVIRT="libvirt"
-LIBVIRT_HOSTNAME=""
 LIBVIRT_URL=""
 
 if [[ -z "$LIBVIRT_URL" ]]; then
     echo "You need to specify the LIBVIRT_URL to be used as Compute Resource."
+    exit 1
 fi
 
 # RHEVM Compute Resource Variables.
@@ -20,6 +20,7 @@ RHEV_PASSWORD=""
 
 if [[ -z "$RHEV_URL" || -z "$RHEV_USERNAME" || -z "$RHEV_PASSWORD" ]]; then
     echo "You need to specify RHEV_URL, RHEV_USERNAME and RHEV_PASSWORD to be used as Compute Resource."
+    exit 1
 fi
 
 # Openstack Compute Resource.
@@ -29,6 +30,7 @@ OS_PASSWORD=""
 
 if [[ -z "$OS_URL" || -z "OS_USERNAME" || -z "$OS_PASSWORD" ]]; then
     echo "You need to specify OS_URL, OS_USERNAME, OS_PASSWORD to be used as Compute Resource."
+    exit 1
 fi
 
 
@@ -41,6 +43,7 @@ SUBNET_GATEWAY=""
 
 if [[ -z "$SUBNET_NAME" || -z "$SUBNET_RANGE" || -z "$SUBNET_MASK" || -z "$SUBNET_GATEWAY" ]]; then
     echo "You need to specify SUBNET_NAME, SUBNET_RANGE, SUBNET_MASK and SUBNET_GATEWAY to be added as a subnet."
+    exit 1
 fi
 
 # Manifest details


### PR DESCRIPTION
a) Reverting to download file satellite6-populate-template via wget

This job uses the automation-tools repo and not the robottelo-ci
repo, hence the revert. Later the plan is to trigger the,
satellite-configure job from satellite6-libvirt-install job.

b) Also update the HTTP_SERVER_NAME in satellite6-populate-template
file.