### PR TITLE
Use requirements.txt for all robottelo branches

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -1,9 +1,4 @@
-# Zstream Job requires it's own requirements and the versions are freezed.
-if [ -f requirements-freeze.txt ]; then
-    pip install -U -r requirements-freeze.txt
-else
-    pip install -U -r requirements.txt docker-py pytest-xdist
-fi
+pip install -U -r requirements.txt docker-py pytest-xdist
 
 cp config/robottelo.properties ./robottelo.properties
 

--- a/scripts/satellite6-standalone-automation.sh
+++ b/scripts/satellite6-standalone-automation.sh
@@ -1,10 +1,6 @@
 set -o nounset
 
-if [ -f "requirements-freeze.txt" ]; then
-    pip install -U -r requirements-freeze.txt
-else
-    pip install -U -r requirements.txt docker-py pytest-xdist
-fi
+pip install -U -r requirements.txt docker-py pytest-xdist
 
 if [ -n "${ROBOTTELO_PROPERTIES:-}" ]; then
     echo "${ROBOTTELO_PROPERTIES}" > ./robottelo.properties


### PR DESCRIPTION
Depends on
https://github.com/SatelliteQE/robottelo/pull/4250  and https://github.com/SatelliteQE/robottelo/pull/4249

All robottelo branches now has requirements pinned versions, no more need to mantain a different requirements file.

Lets make all branches use the `requirements.txt` following the same pattern