### PR TITLE
Changes as per satellite-clone

### DIFF
--- a/jobs/satellite6-upgrader.yaml
+++ b/jobs/satellite6-upgrader.yaml
@@ -73,8 +73,6 @@
             description: |
                 <p>Customer name of which the DB's will be picked to perform upgrade.</p>
         - string:
-            name: DHCP_INTERFACE
-        - string:
             name: CAPSULE_HOSTNAMES
         - string:
             name: CAPSULE_AK


### PR DESCRIPTION
- Recently satellite-clone tool has been updated w/ lot of changes, so accordingly we updated the flow here.
- Clone tool sets the `include_pulp_data` flag to true. We are keeping it false for now as we don't have any db w/ pulp data. Plan is to make it configurable via job itself.
- Now clone tool won't copy the db to the node where db will be restored, user has to copy the db directly.