### PR TITLE
Fixes the SUBNET_NAME issue

### DIFF
--- a/scripts/satellite6-configure-variables.sh
+++ b/scripts/satellite6-configure-variables.sh
@@ -24,7 +24,7 @@ sed -i "s|OS_USERNAME=.*|OS_USERNAME=${OS_USERNAME}|" satellite6-populate.sh
 sed -i "s|OS_PASSWORD=.*|OS_PASSWORD=${OS_PASSWORD}|" satellite6-populate.sh
 
 # Populate the Subnet Information.
-sed -i "s|SUBNET_NAME=.*|SUBNET_NAME=subnet-${SUBNET_RANGE}|" satellite6-populate.sh
+sed -i "s|SUBNET_NAME=.*|SUBNET_NAME=subnet|" satellite6-populate.sh
 sed -i "s|SUBNET_RANGE=.*|SUBNET_RANGE=${SUBNET_RANGE}|" satellite6-populate.sh
 sed -i "s|SUBNET_MASK=.*|SUBNET_MASK=${SUBNET_MASK}|" satellite6-populate.sh
 sed -i "s|SUBNET_GATEWAY=.*|SUBNET_GATEWAY=${SUBNET_GATEWAY}|" satellite6-populate.sh


### PR DESCRIPTION
Fixes the issue Failed to power up a compute libvirt (Libvirt) instance rhel-7.xyz.com : Call to virDomainCreateWithFlags failed: Network interface name 'subnet-0.4.5.0' is too long: Numerical result out of range