### PR TITLE
Longrun and Email Notification update in Standalone Upgrade

### DIFF
--- a/jobs/satellite6-upgrader.yaml
+++ b/jobs/satellite6-upgrader.yaml
@@ -24,10 +24,12 @@
                 - satellite
                 - capsule
                 - client
+                - longrun
             description: |
                 <p><strong>Choosing 'satellite' will upgrade only Satellite.</strong></p>
                 <p><strong>Choosing 'capsule' will upgrade both Capsule as well as its associated Satellite.</strong></p>
                 <p><strong>Choosing 'client' will upgrade Clients as well as its associated Satellite.</strong></p>
+                <p><strong>Choosing 'longrun' will upgrade all i.e Satellite, Capsule and Clients</strong></p>
         - choice:
             name: FROM_VERSION
             choices:
@@ -118,3 +120,13 @@
     publishers:
         - archive:
             artifacts: '*.tar.xz'
+        - email-ext:
+            recipients: $BUILD_USER_EMAIL
+            success: true
+            failure: true
+            subject: 'Your $UPGRADE_PRODUCT upgrade from $FROM_VERSION to $TO_VERSION on $OS finished'
+            body: |
+
+                ${FILE, path="upgrade_highlights"}
+                Build URL: $BUILD_URL
+            attachments: full_upgrade, Log_Analyzer_Logs.tar.xz


### PR DESCRIPTION
DON'T BE SURPRISED next time if you get an Email Notification for your own upgrade standalone job build.
Its here now .....

This PR is for:
1. New option in UPGRADE_PRODUCT , that is 'longrun' which will test Satellite, Capsule as well as clients.
2. Email Notification Update to the the Job owner.