### PR TITLE
Add support for External authentication

### DIFF
--- a/jobs/parameters/satellite6_authentication_parameters.yaml
+++ b/jobs/parameters/satellite6_authentication_parameters.yaml
@@ -1,0 +1,21 @@
+- parameter:
+    name: satellite6-authentication-parameters
+    parameters:
+        - bool:
+            name: IDM_EXTERNAL_AUTH
+            default: false
+            description: |
+                Enrolls Sat6 to IDM and configures External Authentication using IDM as the Auth source.
+                Requires the same Sat6 and IDM Server domain, to work out of the box.
+                The Sat6 Server's first nameserver should be pointing to the IDM Server.
+                One can use test-external-auth VM to test this feature quickly.
+                This will be useful for testing Kerberos/SSO, 2FA, e.t.c features with IDM.
+                Please note, this is not LDAP Authentication.
+        - bool:
+            name: IDM_REALM
+            default: false
+            description: |
+                Enrolls sat6 to IDM and configures Sat6 for REALM Integration.
+                Requires the same Sat6 and IDM Server domain, to work out of the box.
+                The Sat6 Server's first nameserver should be pointing to the IDM Server.
+                This is also called, External Authentication for Provisioned Hosts.

--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -30,6 +30,7 @@
                 Not required in CDN distribution, this content should be enabled/synced from cdn.redhat.com using manifests. |
                 Leaving this blank picks the latest SATTOOLS repo. Override if required.
         - satellite6-provisioning-parameters
+        - satellite6-authentication-parameters
     scm:
         - git:
             url: https://github.com/SatelliteQE/automation-tools.git
@@ -464,6 +465,8 @@
             description: |
                 Leave it blank to install the latest stable. Example: http://example.com/path/to/Satellite/Satellite-6.1.0-RHEL-7-20150311.1/compose/sattools/x86_64/os
         - satellite6-provisioning-parameters
+        - satellite6-authentication-parameters
+
     wrappers:
         - config-file-provider:
             files:
@@ -497,6 +500,8 @@
                 ROBOTTELO_WORKERS=${{ROBOTTELO_WORKERS}}
                 PROXY_MODE=${{PROXY_MODE}}
                 BUILD_LABEL=${{BUILD_LABEL}}
+                IDM_EXTERNAL_AUTH=${{IDM_EXTERNAL_AUTH}}
+                IDM_REALM=${{IDM_REALM}}
         - trigger-builds:
             - project: provisioning-{satellite_version}-rhel7
               predefined-parameters: |
@@ -508,6 +513,8 @@
                 ROBOTTELO_WORKERS=${{ROBOTTELO_WORKERS}}
                 PROXY_MODE=${{PROXY_MODE}}
                 BUILD_LABEL=${{BUILD_LABEL}}
+                IDM_EXTERNAL_AUTH=${{IDM_EXTERNAL_AUTH}}
+                IDM_REALM=${{IDM_REALM}}
         - trigger-builds:
             - project: polarion-test-case
         - trigger-builds:

--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -124,6 +124,7 @@
             default: false
             description: |
                 Install Satellite with Puppet v4 (for Satellite 6.3+ only).
+        - satellite6-authentication-parameters
     scm:
         - git:
             url: https://github.com/SatelliteQE/automation-tools.git

--- a/jobs/satellite6-libvirt-install.yaml
+++ b/jobs/satellite6-libvirt-install.yaml
@@ -71,6 +71,7 @@
             description: |
                 Points to RHSM stage for stage installation test. Used only
                 in CDN provisioning.
+        - satellite6-authentication-parameters
     scm:
         - git:
             url: https://github.com/SatelliteQE/automation-tools.git

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -5,6 +5,7 @@ export OS_VERSION=$(fab -H root@${SERVER_HOSTNAME} distro_info | grep "rhel [[:d
 DISTRO="rhel${OS_VERSION}"
 
 source ${CONFIG_FILES}
+source config/idm_server.conf
 source config/installation_environment.conf
 source config/proxy_config_environment.conf
 # OS_VERSION needs to be defined before sourcing sat6_repos_urls.conf
@@ -17,6 +18,9 @@ fi
 if [ "${PUPPET4}" = 'true' ]; then
     export PUPPET4_REPO # sourced from installation_environment.conf
 fi
+
+export IDM_EXTERNAL_AUTH
+export IDM_REALM
 
 if [ ${FIX_HOSTNAME} = "true" ]; then
     fab -H root@${SERVER_HOSTNAME} fix_hostname

--- a/scripts/satellite6-libvirt-install.sh
+++ b/scripts/satellite6-libvirt-install.sh
@@ -3,6 +3,7 @@ pip install -r requirements.txt
 source ${CONFIG_FILES}
 source config/fake_manifest.conf
 source config/installation_environment.conf
+source config/idm_server.conf
 source config/provision_libvirt_install.conf
 source config/proxy_config_environment.conf
 source config/subscription_config.conf
@@ -12,6 +13,9 @@ source config/compute_resources.conf
 if [ "${STAGE_TEST}" = 'true' ]; then
     source config/stage_environment.conf
 fi
+
+export IDM_EXTERNAL_AUTH
+export IDM_REALM
 
 function remove_instance () {
     # For Example: The TARGET_IMAGE in provision_libvirt_install.conf should be "qe-test-rhel7".

--- a/scripts/satellite6-provisioning.sh
+++ b/scripts/satellite6-provisioning.sh
@@ -2,6 +2,7 @@ pip install -r requirements.txt
 
 source ${CONFIG_FILES}
 source config/fake_manifest.conf
+source config/idm_server.conf
 source config/installation_environment.conf
 source config/provisioning_environment.conf
 source config/proxy_config_environment.conf
@@ -12,6 +13,8 @@ fi
 if [ "${PUPPET4}" = 'true' ]; then
     export PUPPET4_REPO # sourced from installation_environment.conf
 fi
+export IDM_EXTERNAL_AUTH
+export IDM_REALM
 
 # The target_image in provisioning_environment.conf should be "qe-sat6y-rhel7-base".
 export TARGET_IMAGE


### PR DESCRIPTION
a) We can now select whether to configure External Authentication.
b) We can now select whether to configure REALM Integration.
c) Selecting either will automatically enroll the Satellite6 to
   the IDM Server.