### PR TITLE
Fix the IMAGE jenkins parameter visible for the trigger job.

### DIFF
--- a/jobs/parameters/satellite6_provisioning_parameters.yaml
+++ b/jobs/parameters/satellite6_provisioning_parameters.yaml
@@ -36,7 +36,3 @@
             default: false
             description: |
                 Install Satellite with Puppet v4 (for Satellite 6.3+ only).
-        - string:
-            name: IMAGE
-            description: |
-                Specify RHEL source image to be used for automation.

--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -28,6 +28,10 @@
             name: TOOLS_URL
             description: Required when Satellite distribution is INTERNAL and we require latest SatTools Client packages. |
                 Not required in CDN distribution, this content should be enabled/synced from cdn.redhat.com using manifests. |
+        - string:
+            name: IMAGE
+            description: |
+                Specify RHEL source image to be used for automation.
                 Leaving this blank picks the latest SATTOOLS repo. Override if required.
         - satellite6-provisioning-parameters
         - satellite6-authentication-parameters


### PR DESCRIPTION
a) IMAGE jenkins parameter should only be visible for the provisioning
   job and not for the trigger job.
b) Removed the IMAGE jenkins parameter from the macro.