### PR TITLE
Forgot the Clients Count to Generate and Upgrade during Upgrade

### DIFF
--- a/scripts/satellite6-upgrade-trigger.sh
+++ b/scripts/satellite6-upgrade-trigger.sh
@@ -9,6 +9,7 @@ export DISTRO="${{OS}}"
 export OS_VERSION="${{OS: -1}}"
 export TO_VERSION="${{SATELLITE_VERSION}}"
 export FROM_VERSION=$(echo ${{SATELLITE_VERSION}} - 0.1 | bc)
+export CLIENTS_COUNT=8
 
 # Sourcing and exporting required env vars
 source "${{CONFIG_FILES}}"


### PR DESCRIPTION
/me forgot big thing to mention the client count in upgrade trigger

I didnt add / export CLIENTS_COUNT parameter earlier neither from trigger job as parameter nor hard-coded count. Which would have lead to upgrade trigger job failure.

So solving this issue with hard-coding the clients count value to 8. And NOT adding CLIENTS_COUNT as job parameter because we have limited subscriptions in satellite upgrade box and we dont want the count to be higher than expected.

So hard-coding the number of clients later we can increase the clients.

Thanks for understanding.!! :)