### PR TITLE
Drop removal of Pylarion config file

### DIFF
--- a/jobs/satellite6-betelgeuse.yaml
+++ b/jobs/satellite6-betelgeuse.yaml
@@ -22,7 +22,6 @@
                 !include-raw:
                     - scripts/satellite6-betelgeuse.sh
                     - scripts/satellite6-betelgeuse-test-case.sh
-        - shell: rm .pylarion
 
 
 - job-template:
@@ -75,4 +74,3 @@
                 !include-raw-escape:
                     - scripts/satellite6-betelgeuse.sh
                     - scripts/satellite6-betelgeuse-test-run.sh
-        - shell: rm .pylarion


### PR DESCRIPTION
Drop removal of Pylarion config file because now the jobs are using
environment variables instead of the config file.