### PR TITLE
Upgrade Trigger Job updated for Zstream Upgrade

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -348,6 +348,12 @@
             description: |
                 Number of workers to use while running robottelo tier1 test suite
                 after the upgrade.
+        - bool:
+            name: ZSTREAM_UPGRADE
+            default: false
+            description: |
+                This option is helpful in manually triggering this job for zStream upgrade.
+                e.g 6.2.7 to 6.2.8
     scm:
         - git:
             url: https://github.com/SatelliteQE/automation-tools.git

--- a/scripts/satellite6-upgrade-trigger.sh
+++ b/scripts/satellite6-upgrade-trigger.sh
@@ -8,7 +8,11 @@ export SATELLITE_VERSION="{satellite_version}"
 export DISTRO="${{OS}}"
 export OS_VERSION="${{OS: -1}}"
 export TO_VERSION="${{SATELLITE_VERSION}}"
-export FROM_VERSION=$(echo ${{SATELLITE_VERSION}} - 0.1 | bc)
+if [ "${{ZSTREAM_UPGRADE}}" = 'true' ]; then
+    export FROM_VERSION="${{TO_VERSION}}"
+else
+    export FROM_VERSION=$(echo ${{SATELLITE_VERSION}} - 0.1 | bc)
+fi
 export CLIENTS_COUNT=8
 
 # Sourcing and exporting required env vars


### PR DESCRIPTION
Only Upgrade Trigger Job in master trigger job is updated to run manually a zStream upgrade that will send status Email directly to KATELLO QE.