### PR TITLE
[Do Not Merge ] Update how the custom-fields are specified.

### DIFF
--- a/scripts/satellite6-betelgeuse-test-run.sh
+++ b/scripts/satellite6-betelgeuse-test-run.sh
@@ -13,12 +13,12 @@ SANITIZED_ITERATION_ID="$(echo ${TEST_RUN_ID} | sed 's|\.|_|g' | sed 's| |_|g')"
 # Prepare the XML files
 for tier in $(seq 1 4); do
    for run in parallel sequential; do
-        betelgeuse --token-prefix="@" xml-test-run \
-            --custom-fields="isautomated=true" \
-            --custom-fields="arch=x8664" \
-            --custom-fields="variant=server" \
-            --custom-fields="plannedin=${SANITIZED_ITERATION_ID}" \
-            --response-property="${POLARION_SELECTOR}" \
+        betelgeuse --token-prefix @ xml-test-run \
+            --custom-fields isautomated=true \
+            --custom-fields arch=x8664 \
+            --custom-fields variant=server \
+            --custom-fields plannedin="${SANITIZED_ITERATION_ID}" \
+            --response-property "${POLARION_SELECTOR}" \
             --test-run-id "${TEST_RUN_ID} - ${run} - Tier ${tier}" \
             "./tier${tier}-${run}-results.xml" \
             tests/foreman \


### PR DESCRIPTION
a) specify the custom-fields with space rather than '='
b) The examples of betelgeuse suggests to use spaces.