### PR TITLE
Change the node from sesame to sat6-rhel6 which is paprika host.

### DIFF
--- a/jobs/release/sat6-release-compose.yaml
+++ b/jobs/release/sat6-release-compose.yaml
@@ -4,7 +4,7 @@
       daysToKeep: -1
       numToKeep: 32
     concurrent: true
-    node: sesame
+    node: sat6-rhel6
     parameters:
       - string:
           name: version

--- a/jobs/release/sat6-release-install-test.yaml
+++ b/jobs/release/sat6-release-install-test.yaml
@@ -4,7 +4,7 @@
       daysToKeep: -1
       numToKeep: 32
     concurrent: true
-    node: sesame
+    node: sat6-rhel6
     parameters:
       - string:
           name: organization

--- a/jobs/release/sat6-release-promote-dev.yaml
+++ b/jobs/release/sat6-release-promote-dev.yaml
@@ -4,7 +4,7 @@
       daysToKeep: -1
       numToKeep: 32
     concurrent: true
-    node: sesame
+    node: sat6-rhel6
     parameters:
       - string:
           name: organization

--- a/jobs/release/sat6-release-promote-test.yaml
+++ b/jobs/release/sat6-release-promote-test.yaml
@@ -4,7 +4,7 @@
       daysToKeep: -1
       numToKeep: 32
     concurrent: true
-    node: sesame
+    node: sat6-rhel6
     parameters:
       - string:
           name: organization

--- a/jobs/release/sat6-release-publish-content-view.yaml
+++ b/jobs/release/sat6-release-publish-content-view.yaml
@@ -4,7 +4,7 @@
       daysToKeep: -1
       numToKeep: 32
     concurrent: true
-    node: sesame
+    node: sat6-rhel6
     parameters:
       - string:
           name: organization

--- a/jobs/release/sat6-release.yaml
+++ b/jobs/release/sat6-release.yaml
@@ -3,7 +3,7 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 32
-    node: sesame
+    node: sat6-rhel6
     parameters:
       - choice:
           name: version

--- a/jobs/robottelo-ci-update-jobs.yaml
+++ b/jobs/robottelo-ci-update-jobs.yaml
@@ -1,6 +1,6 @@
 - job:
     name: robottelo-ci-update-jobs
-    node: sesame
+    node: sat6-rhel6
     scm:
         - git:
             url: https://github.com/SatelliteQE/robottelo-ci.git

--- a/jobs/satellite5-installer.yaml
+++ b/jobs/satellite5-installer.yaml
@@ -8,7 +8,7 @@
         <pre>
         ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAzoPajR2xtQOAfBebX69Mx9Ee4P/LMqlxQLKvF0bc79/1ayMf3IrmpY1V6JCpABvMV1830I9D9x9Tr8E9zjg2wWT14hhHsrUKSWUsy3doIwz3MtISBZPMig5AizVjH6Wl/t833zgkeHtStCYI/bmJQykj6AgB8/A4L5SRIpNnl1q7V+sw37Rmumaiqu4lRDXyTXY7mlOCuxrus/WcGyVTh2k+oBVqkz2V2s3+Or8Zy2Y441B4z3vF3lE6aoIBwidBVZ1LKaofZDMRf/lu575cI4AB3N5DQvpqwLSc4+HIvog0FdKUo3qMaFgg0KNkYS5fnpDpRDRQnFw7oFnBHiPNqw== jenkins@satellite-jenkins
         </pre>
-    node: sesame
+    node: sat6-rhel6
     parameters:
         - string:
             name: SERVER_HOSTNAME

--- a/jobs/satellite6-automation-cleanup.yaml
+++ b/jobs/satellite6-automation-cleanup.yaml
@@ -1,6 +1,6 @@
 - job:
     name: satellite6-automation-cleanup
-    node: sesame
+    node: sat6-rhel6
     concurrent: false 
     description: |
         <p>Job that runs cleanup scripts.  Currently this only runs container cleanup.</p>

--- a/jobs/satellite6-automation-performance-report.yaml
+++ b/jobs/satellite6-automation-performance-report.yaml
@@ -1,6 +1,6 @@
 - job:
     name: 'satellite6-automation-performance-report'
-    node: sesame
+    node: sat6-rhel6
     parameters:
         - choice:
             name: OS

--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -3,7 +3,7 @@
 #==============================================================================
 - job-template:
     name: 'provisioning-{satellite_version}-{os}'
-    node: sesame
+    node: sat6-rhel6
     parameters:
         - choice:
             name: SATELLITE_DISTRIBUTION
@@ -86,7 +86,7 @@
 
 - job-template:
     name: 'automation-{satellite_version}-tier1-{os}'
-    node: sesame
+    node: sat6-rhel6
     logrotate:
         numToKeep: 16
     properties:
@@ -134,7 +134,7 @@
 
 - job-template:
     name: 'automation-{satellite_version}-tier2-{os}'
-    node: sesame
+    node: sat6-rhel6
     logrotate:
         numToKeep: 16
     properties:
@@ -167,7 +167,7 @@
 
 - job-template:
     name: 'automation-{satellite_version}-tier3-{os}'
-    node: sesame
+    node: sat6-rhel6
     logrotate:
         numToKeep: 16
     properties:
@@ -201,7 +201,7 @@
 
 - job-template:
     name: 'automation-{satellite_version}-rhai-{os}'
-    node: sesame
+    node: sat6-rhel6
     logrotate:
         numToKeep: 16
     properties:
@@ -242,7 +242,7 @@
 
 - job-template:
     name: 'automation-{satellite_version}-tier4-{os}'
-    node: sesame
+    node: sat6-rhel6
     logrotate:
         numToKeep: 16
     properties:
@@ -335,7 +335,7 @@
 - job-template:
     name: 'upgrade-to-{satellite_version}-{os}'
     concurrent: true
-    node: sesame
+    node: sat6-rhel6
     parameters:
         - string:
             name: BUILD_LABEL
@@ -402,7 +402,7 @@
 
 - job-template:
     name: 'automation-upgraded-{satellite_version}-tier1-{os}'
-    node: sesame
+    node: sat6-rhel6
     logrotate:
         numToKeep: 16
     properties:
@@ -442,7 +442,7 @@
 - job-template:
     name: trigger-satellite{satellite_version}
     description: Triggers automation for Satellite 6
-    node: sesame
+    node: sat6-rhel6
     parameters:
         - choice:
             name: SATELLITE_DISTRIBUTION
@@ -598,7 +598,7 @@
 - job:
     name: trigger-nightly
     description: Triggers automation for Satellite 6 upstream using katello-deploy.
-    node: sesame
+    node: sat6-rhel6
     parameters:
         - string:
             name: ROBOTTELO_WORKERS

--- a/jobs/satellite6-betelgeuse.yaml
+++ b/jobs/satellite6-betelgeuse.yaml
@@ -1,6 +1,6 @@
 - job:
     name: polarion-test-case
-    node: sesame
+    node: sat6-rhel6
     scm:
         - git:
             url: https://github.com/SatelliteQE/robottelo.git
@@ -28,7 +28,7 @@
 
 - job-template:
     name: polarion-test-run-{satellite_version}-{os}
-    node: sesame
+    node: sat6-rhel6
     scm:
         - git:
             url: https://github.com/SatelliteQE/robottelo.git

--- a/jobs/satellite6-generate-compose.yaml
+++ b/jobs/satellite6-generate-compose.yaml
@@ -3,7 +3,7 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 32
-    node: sesame
+    node: sat6-rhel6
     concurrent: true
     parameters:
       - choice:

--- a/jobs/satellite6-handle-tier-instances.yaml
+++ b/jobs/satellite6-handle-tier-instances.yaml
@@ -2,7 +2,7 @@
     name: 'satellite6-handle-tier-instances'
     description: |
         Quickly launch or destroy the tier instances of various jobs.
-    node: sesame
+    node: sat6-rhel6
     parameters:
         - choice:
             name: SATELLITE_VERSION

--- a/jobs/satellite6-install-test.yaml
+++ b/jobs/satellite6-install-test.yaml
@@ -4,7 +4,7 @@
       daysToKeep: -1
       numToKeep: 32
     concurrent: true
-    node: sesame
+    node: sat6-rhel6
     parameters:
       - string:
           name: rhel

--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -8,7 +8,7 @@
         <pre>
         ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAzoPajR2xtQOAfBebX69Mx9Ee4P/LMqlxQLKvF0bc79/1ayMf3IrmpY1V6JCpABvMV1830I9D9x9Tr8E9zjg2wWT14hhHsrUKSWUsy3doIwz3MtISBZPMig5AizVjH6Wl/t833zgkeHtStCYI/bmJQykj6AgB8/A4L5SRIpNnl1q7V+sw37Rmumaiqu4lRDXyTXY7mlOCuxrus/WcGyVTh2k+oBVqkz2V2s3+Or8Zy2Y441B4z3vF3lE6aoIBwidBVZ1LKaofZDMRf/lu575cI4AB3N5DQvpqwLSc4+HIvog0FdKUo3qMaFgg0KNkYS5fnpDpRDRQnFw7oFnBHiPNqw== jenkins@satellite-jenkins
         </pre>
-    node: sesame
+    node: sat6-rhel6
     parameters:
         - string:
             name: SERVER_HOSTNAME

--- a/jobs/satellite6-libvirt-install.yaml
+++ b/jobs/satellite6-libvirt-install.yaml
@@ -3,7 +3,7 @@
     description: |
         Quickly up an instance using VLANs for feature and Bug testing. We could use the two new physical hardware which were
         recently procured. This would help fully automate sat6 installation to do Libvirt, RHEVM and Openstack CR Testing.
-    node: sesame
+    node: sat6-rhel6
     parameters:
         - choice:
             name: PROVISIONING_ID

--- a/jobs/satellite6-manifest-downloader.yaml
+++ b/jobs/satellite6-manifest-downloader.yaml
@@ -5,7 +5,7 @@
         Downloads the Satellite6 Manifest from access.redhat.com
     triggers:
         - timed: '00 17 * * 0'
-    node: sesame
+    node: sat6-rhel6
     scm:
         - git:
             url: https://github.com/SatelliteQE/automation-tools.git

--- a/jobs/satellite6-populate.yaml
+++ b/jobs/satellite6-populate.yaml
@@ -8,7 +8,7 @@
         <pre>
         ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAzoPajR2xtQOAfBebX69Mx9Ee4P/LMqlxQLKvF0bc79/1ayMf3IrmpY1V6JCpABvMV1830I9D9x9Tr8E9zjg2wWT14hhHsrUKSWUsy3doIwz3MtISBZPMig5AizVjH6Wl/t833zgkeHtStCYI/bmJQykj6AgB8/A4L5SRIpNnl1q7V+sw37Rmumaiqu4lRDXyTXY7mlOCuxrus/WcGyVTh2k+oBVqkz2V2s3+Or8Zy2Y441B4z3vF3lE6aoIBwidBVZ1LKaofZDMRf/lu575cI4AB3N5DQvpqwLSc4+HIvog0FdKUo3qMaFgg0KNkYS5fnpDpRDRQnFw7oFnBHiPNqw== jenkins@satellite-jenkins
         </pre>
-    node: sesame
+    node: sat6-rhel6
     scm:
         - git:
             url: https://github.com/SatelliteQE/robottelo-ci.git

--- a/jobs/satellite6-upgrader.yaml
+++ b/jobs/satellite6-upgrader.yaml
@@ -16,7 +16,7 @@
         ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAzoPajR2xtQOAfBebX69Mx9Ee4P/LMqlxQLKvF0bc79/1ayMf3IrmpY1V6JCpABvMV1830I9D9x9Tr8E9zjg2wWT14hhHsrUKSWUsy3doIwz3MtISBZPMig5AizVjH6Wl/t833zgkeHtStCYI/bmJQykj6AgB8/A4L5SRIpNnl1q7V+sw37Rmumaiqu4lRDXyTXY7mlOCuxrus/WcGyVTh2k+oBVqkz2V2s3+Or8Zy2Y441B4z3vF3lE6aoIBwidBVZ1LKaofZDMRf/lu575cI4AB3N5DQvpqwLSc4+HIvog0FdKUo3qMaFgg0KNkYS5fnpDpRDRQnFw7oFnBHiPNqw== jenkins@satellite-jenkins
         </pre>
         <p><strong>Failing to add ssh-key will result in job fail.</strong></p>
-    node: sesame
+    node: sat6-rhel6
     parameters:
         - choice:
             name: UPGRADE_PRODUCT


### PR DESCRIPTION
a) sesame is down due to FileSystem issues and there is no ETA for
   it.
b) Also proposing to rename sesame to sat6-rhel7 and paprika to
   sat6-rhel6.
c) The idea is to have 2 separate nodes, one for rhel6 jobs and
   the other for rhel7 jobs.
d) currently as sesame aka sat6-rhel7 is down all jobs would
   utilize paprika aka sat6-rhel6 only.
e) Moving forward the jobs that are os dependent would make use
   of the following jenkins variable {os}, so that the node that
   we would specify would be sat6-{os}.