### PR TITLE
Added a flag to perform upgrade w/ or w/o pulp data

### DIFF
--- a/jobs/satellite6-upgrader.yaml
+++ b/jobs/satellite6-upgrader.yaml
@@ -74,6 +74,12 @@
                 <p>Select the Customer DB for upgrade</p>
                 <p>For Lidl, <b>From version</b> should be <b>6.1</b> and OS should be <b>RHEL7</b></p>
                 <p>For ExpressScript, <b>From version</b> should be <b>6.2</b> and OS should be <b>RHEL7</b></p>
+        - bool:
+            name: INCLUDE_PULP_DATA
+            default: false
+            description: 
+                <p>Select if you would like to perfrom Customer DB upgrade with pulp data</p>
+                <p>Make sure the selected DB should have the pulp data before selecting this check</p>
         - string:
             name: SATELLITE_HOSTNAME
             description: |

--- a/scripts/satellite6_upgrader.sh
+++ b/scripts/satellite6_upgrader.sh
@@ -64,7 +64,7 @@ if [ "${CUSTOMERDB_NAME}" != 'None' ]; then
     sed -i -e "s/^activationkey.*/activationkey: "test_ak"/" satellite-clone-vars.yml
     sed -i -e "s/^org.*/org: "Default\ Organization"/" satellite-clone-vars.yml
     sed -i -e "s/^#backup_dir.*/backup_dir: "${BACKUP_DIR}"/" satellite-clone-vars.yml
-    sed -i -e "s/^#include_pulp_data.*/include_pulp_data: false/" satellite-clone-vars.yml
+    sed -i -e "s/^#include_pulp_data.*/include_pulp_data: "${INCLUDE_PULP_DATA}"/" satellite-clone-vars.yml
     # Note: Statements related to RHN_POOLID, RHN_PASSWORD, RHN_USERNAME and OS_VERSION added to support satellite6 upgrade through CDN
     # There are no such variables defined in satellite-clone-vars-sample.yaml
     sed -i -e "/org.*/arhn_pool: "${RHN_POOLID}"" satellite-clone-vars.yml


### PR DESCRIPTION
- Satellite-Clone tool now supports upgrade w/ pulp data as well. But the databases that we have been using for cust-db upgrade doesn't include pulp data. However, if we would get DB w/ pulp data then we can easily test that out.

- So, added a flag in job and default set it to `false`.