### PR TITLE
Fix sed for ddns_package_url

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -14,7 +14,7 @@ sed -i "s/^# \[capsule\].*/[capsule]/" robottelo.properties
 sed -i "s/^# instance_name.*/instance_name=${SERVER_HOSTNAME%%.*}-capsule/" robottelo.properties
 sed -i "s/^# domain.*/domain=${DDNS_DOMAIN}/" robottelo.properties
 sed -i "s/^# hash.*/hash=${DDNS_HASH}/" robottelo.properties
-sed -i "s/^# ddns_package_url=${DDNS_PACKAGE_URL}/" robottelo.properties
+sed -i "s|^# ddns_package_url.*|ddns_package_url=${DDNS_PACKAGE_URL}|" robottelo.properties
 
 # Robottelo logging configuration
 sed -i "s/'\(robottelo\).log'/'\1-${ENDPOINT}.log'/" logging.conf


### PR DESCRIPTION
```
+ sed -i 's/^# ddns_package_url=http://SERVER/rhel7-csb-stage/RPMS/noarch/redhat-internal-ddns-client-1.3-10.el7.csb.noarch.rpm/' robottelo.properties
sed: -e expression #1, char 30: unknown option to `s'
```