### PR TITLE
fixes #431 - include screenshots in the published archive

### DIFF
--- a/jobs/publishers/satellite6_automation_archiver.yaml
+++ b/jobs/publishers/satellite6_automation_archiver.yaml
@@ -2,5 +2,5 @@
     name: satellite6-automation-archiver
     publishers:
         - archive:
-            artifacts: 'robottelo*.log,insights*.log,*-results.xml,foreman-debug.tar.xz'
+            artifacts: 'robottelo*.log,insights*.log,*-results.xml,foreman-debug.tar.xz,screenshots/*/*.png'
             allow-empty: true


### PR DESCRIPTION
addresses https://github.com/SatelliteQE/robottelo-ci/issues/431

- include `screenshots` directory in the published archive