### PR TITLE
Run nightly every 2 days

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -673,7 +673,7 @@
             name: SATELLITE_DISTRIBUTION
             default: 'UPSTREAM'
     triggers:
-        - timed: 'H 19 * * *'
+        - timed: 'H 19 * * */2'
     builders:
         - shell:
             echo "BUILD_LABEL=Upstream Nightly-$(date +%Y-%m-%d)" > properties.txt


### PR DESCRIPTION
Run nightly every 2 days so that all tiers manage to finish and there will be some time left for results investigation.

(later on we can find out what days work best)