### PR TITLE
Drop betelgeuse --token-prefix option

### DIFF
--- a/scripts/satellite6-betelgeuse-test-case.sh
+++ b/scripts/satellite6-betelgeuse-test-case.sh
@@ -1,2 +1,2 @@
-betelgeuse --token-prefix "@" test-case \
+betelgeuse test-case \
     --path tests/foreman "${POLARION_PROJECT}"

--- a/scripts/satellite6-betelgeuse-test-run.sh
+++ b/scripts/satellite6-betelgeuse-test-run.sh
@@ -23,7 +23,7 @@ SANITIZED_ITERATION_ID="$(echo ${TEST_RUN_ID} | sed 's|\.|_|g' | sed 's| |_|g')"
 # Prepare the XML files
 for tier in $(seq 1 4); do
    for run in parallel sequential; do
-        betelgeuse --token-prefix "@" xml-test-run \
+        betelgeuse xml-test-run \
             --custom-fields "isautomated=true" \
             --custom-fields "arch=x8664" \
             --custom-fields "variant=server" \


### PR DESCRIPTION
Now Robottelo uses `:` as the tokens prefix and the `--token-prefix`
Betelgeuse option is not needed anymore.