### PR TITLE
IDM and AD EXTERNAL_AUTH are now mutually exclusive

### DIFF
--- a/jobs/parameters/satellite6_authentication_parameters.yaml
+++ b/jobs/parameters/satellite6_authentication_parameters.yaml
@@ -1,15 +1,19 @@
 - parameter:
     name: satellite6-authentication-parameters
     parameters:
-        - bool:
-            name: IDM_EXTERNAL_AUTH
-            default: false
+        - choice:
+            name: EXTERNAL_AUTH
+            choices:
+                - 'NO_AUTH'
+                - 'IDM'
+                - 'AD'
             description: |
-                Enrolls Sat6 to IDM and configures External Authentication using IDM as the Auth source.
-                Requires the same Sat6 and IDM Server domain, to work out of the box.
+                Enrolls Sat6 to IDM or AD and configures External Authentication using IDM or AD as the Auth source.
+                Requires the same Sat6 and IDM or AD Server domain, to work out of the box.
                 The Sat6 Server's first nameserver should be pointing to the IDM Server.
-                One can use test-external-auth VM to test this feature quickly.
-                This will be useful for testing Kerberos/SSO, 2FA, e.t.c features with IDM.
+                One can use test-external-auth VM to test this feature quickly for IDM EXTERNAL_AUTH
+                One can use the Windows AD VM itself to test this feature quickly for AD EXTERNAL_AUTH
+                This will be useful for testing Kerberos/SSO, 2FA, e.t.c features with IDM or AD.
                 Please note, this is not LDAP Authentication.
         - bool:
             name: IDM_REALM
@@ -19,13 +23,3 @@
                 Requires the same Sat6 and IDM Server domain, to work out of the box.
                 The Sat6 Server's first nameserver should be pointing to the IDM Server.
                 This is also called, External Authentication for Provisioned Hosts.
-        - bool:
-            name: AD_EXTERNAL_AUTH
-            default: false
-            description: |
-                Enrolls Sat6 to AD and configures External Authentication using AD as the Auth Source.
-                Requires the same Sat6 and AD Server domain, to work out of the box.
-                The Sat6 Server's first nameserver should be pointing to the AD Server.
-                One can use test-externalad-auth VM to test this feature quickly.
-                This will be useful for testing Kerbero/SSO, 2FA, e.t.c features with AD.
-                Please note, this is not AD Authentication.

--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -587,7 +587,7 @@
                 ROBOTTELO_WORKERS=${{ROBOTTELO_WORKERS}}
                 PROXY_MODE=${{PROXY_MODE}}
                 BUILD_LABEL=${{BUILD_LABEL}}
-                IDM_EXTERNAL_AUTH=${{IDM_EXTERNAL_AUTH}}
+                EXTERNAL_AUTH=${{EXTERNAL_AUTH}}
                 IDM_REALM=${{IDM_REALM}}
                 IMAGE=${{RHEL6_IMAGE}}
         - trigger-builds:
@@ -601,7 +601,7 @@
                 ROBOTTELO_WORKERS=${{ROBOTTELO_WORKERS}}
                 PROXY_MODE=${{PROXY_MODE}}
                 BUILD_LABEL=${{BUILD_LABEL}}
-                IDM_EXTERNAL_AUTH=${{IDM_EXTERNAL_AUTH}}
+                EXTERNAL_AUTH=${{EXTERNAL_AUTH}}
                 IDM_REALM=${{IDM_REALM}}
                 IMAGE=${{RHEL7_IMAGE}}
         - trigger-builds:

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -19,8 +19,7 @@ if [ "${PUPPET4}" = 'true' ]; then
     export PUPPET4_REPO # sourced from installation_environment.conf
 fi
 
-export AD_EXTERNAL_AUTH
-export IDM_EXTERNAL_AUTH
+export EXTERNAL_AUTH
 export IDM_REALM
 
 if [ ${FIX_HOSTNAME} = "true" ]; then

--- a/scripts/satellite6-libvirt-install.sh
+++ b/scripts/satellite6-libvirt-install.sh
@@ -14,8 +14,7 @@ if [ "${STAGE_TEST}" = 'true' ]; then
     source config/stage_environment.conf
 fi
 
-export AD_EXTERNAL_AUTH
-export IDM_EXTERNAL_AUTH
+export EXTERNAL_AUTH
 export IDM_REALM
 
 function remove_instance () {

--- a/scripts/satellite6-provisioning.sh
+++ b/scripts/satellite6-provisioning.sh
@@ -14,8 +14,7 @@ if [ "${PUPPET4}" = 'true' ]; then
     export PUPPET4_REPO # sourced from installation_environment.conf
 fi
 
-export AD_EXTERNAL_AUTH
-export IDM_EXTERNAL_AUTH
+export EXTERNAL_AUTH
 export IDM_REALM
 
 # The target_image in provisioning_environment.conf should be "qe-sat6y-rhel7-base".


### PR DESCRIPTION
Earlier IDM_EXTERNAL_AUTH and AD_EXTERNAL_AUTH were boolean values
and both could be selected. Where as only one can be selected as
they are mutually exclusive and the only way to get EXTERNAL_AUTH
work with both of them is by establishing CROSS-REALM TRUST
between them.