### PR TITLE
Defined job to perform customer DB upgrade and migration

### DIFF
--- a/jobs/parameters/satellite6_upgrade_parameters.yaml
+++ b/jobs/parameters/satellite6_upgrade_parameters.yaml
@@ -1,0 +1,27 @@
+- parameter:
+    name: satellite6-upgrade-parameters
+    parameters:
+        - choice:
+            name: FROM_VERSION
+            choices:
+                - '6.2'
+                - '6.1'
+            description: |
+                <p>Select currently installed Satellite version</p>
+        - choice:
+            name: TO_VERSION
+            choices:
+                - '6.2'
+                - '6.3'
+            description: |
+                <p>Select the Satellite version to upgrade</p>
+        - choice:
+            name: DISTRIBUTION
+            choices:
+                - CDN
+                - DOWNSTREAM
+            description: |
+                <p><strong>CDN</strong>-Upgrade to released version from CDN.</p>
+                <p><strong>DOWNSTREAM</strong>-Upgrade to latest stable internal compose.</p>
+
+

--- a/jobs/satellite6-db-upgrade-migrate.yaml
+++ b/jobs/satellite6-db-upgrade-migrate.yaml
@@ -1,0 +1,100 @@
+- job:
+    name: 'satellite6_db_upgrade_migrate'
+    concurrent: True
+    display-name: 'Satellite6 DB Upgrade & Migrate'
+    description: |
+        <p> Job to perform Customer DB upgrade and migrate RHEL6 Satellite to RHEL7 instance </p>
+        <p> Please make sure to add following ssh-key manually to your Satellite Host otherwise job will fail.</p>
+        <hr>
+        <p><strong>SSH KEY:</strong></p>
+        <pre>
+        ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAzoPajR2xtQOAfBebX69Mx9Ee4P/LMqlxQLKvF0bc79/1ayMf3IrmpY1V6JCpABvMV1830I9D9x9Tr8E9zjg2wWT14hhHsrUKSWUsy3doIwz3MtISBZPMig5AizVjH6Wl/t833zgkeHtStCYI/bmJQykj6AgB8/A4L5SRIpNnl1q7V+sw37Rmumaiqu4lRDXyTXY7mlOCuxrus/WcGyVTh2k+oBVqkz2V2s3+Or8Zy2Y441B4z3vF3lE6aoIBwidBVZ1LKaofZDMRf/lu575cI4AB3N5DQvpqwLSc4+HIvog0FdKUo3qMaFgg0KNkYS5fnpDpRDRQnFw7oFnBHiPNqw== jenkins@satellite-jenkins
+        </pre>
+    node: sat6-rhel6
+    parameters:
+        - choice:
+            name: UPGRADE_PRODUCT
+            choices:
+                - satellite
+            description: |
+                <p><strong>Performs Satellite upgrade.</strong></p>
+        - satellite6-upgrade-parameters
+        - choice:
+            name: OS
+            choices:
+                - rhel7
+                - rhel6
+            description: |
+                <p> Select OS version of target Satellite </p>
+                <p>For <b>Customer DB upgrade</b>, the OS version of target satellite should be similar to OS of Source DB satellite</p>
+                <p>For <b>Migration</b>, the OS of target Satellite machine should always be RHEL7</p>
+        - choice:
+            name: CUSTOMERDB_NAME
+            choices:
+                - 'NoDB'
+                - 'Lidl'
+                - 'ExpressScripts'
+                - 'Sat62RHEL6Migrate'
+            description: |
+                <p>Select the Customer DB for <b>Upgrade</b> OR <b>Migration</b></p>
+                <p>For Lidl, <b>From version</b> should be <b>6.1</b> and OS should be <b>RHEL7</b></p>
+                <p>For ExpressScript, <b>From version</b> should be <b>6.2</b> and OS should be <b>RHEL7</b></p>
+                <p>For Sat62RHEL6Migrate, <b>From version</b> should be <b>6.2</b> and OS should be <b>RHEL7</b></p>
+        - bool:
+            name: INCLUDE_PULP_DATA
+            default: false
+            description: 
+                <p>Select if you would like to perfrom Cutomer DB upgrade or migration with pulp data</p>
+                <p>Make sure the selected DB should have the pulp data before selecting this check</p>
+        - bool:
+            name: RHEL_MIGRATION
+            default: false
+            description: |
+                <p>Select if you would like to perfrom migration of rhel6 Satellite server to rhel7 machine</p>
+                <p>Make sure the selected DB should have the backup files created via katello-backup</p>
+                <p>and foreman.dump and candlepin.dump files</p>
+        - bool:
+            name: PERFORM_UPGRADE
+            default: true
+            description: |
+                <p>Un-Check if you do not want to perform upgrade post Satellite Clone or Migration</p>
+        - string:
+            name: SATELLITE_HOSTNAME
+            description: |
+                <p>This can be the user satellite onto which Satellite-clone, Migrate and Upgrade will be performed.</p>
+    scm:
+        - git:
+            url: https://github.com/SatelliteQE/automation-tools.git
+            branches:
+                - origin/master
+            skip-tag: true
+    wrappers:
+        - build-name:
+            name: '#${BUILD_NUMBER} ${ENV,var="UPGRADE_PRODUCT"}_from_${ENV,var="FROM_VERSION"}_to_${ENV,var="TO_VERSION"}_${ENV,var="OS"}_CustDB_Upgrade:${ENV,var="SATELLITE_HOSTNAME"}'
+        - build-user-vars
+        - config-file-provider:
+            files:
+                - file-id: bc5f0cbc-616f-46de-bdfe-2e024e84fcbf
+                  variable: CONFIG_FILES
+        - default-wrappers
+    builders:
+          - shining-panda:
+              build-environment: virtualenv
+              python-version: System-CPython-2.7
+              clear: true
+              nature: shell
+              command:
+                !include-raw:
+                    - 'pip-install-pycurl.sh'
+                    - 'satellite6_db_upgrade_migrate.sh'
+    publishers:
+        - email-ext:
+            recipients: $BUILD_USER_EMAIL
+            success: true
+            failure: true
+            subject: 'Your $UPGRADE_PRODUCT Upgrade OR migration from $FROM_VERSION to $TO_VERSION on $OS finished'
+            body: |
+                
+                ${FILE, path="upgrade_highlights"}
+                Build URL: $BUILD_URL
+            attachments: full_upgrade, Log_Analyzer_Logs.tar.xz

--- a/scripts/satellite6_db_upgrade_migrate.sh
+++ b/scripts/satellite6_db_upgrade_migrate.sh
@@ -1,0 +1,105 @@
+pip install -U -r requirements.txt
+
+# Set OS version for further use
+export OS_VERSION="${OS#rhel}"
+
+source ${CONFIG_FILES}
+# Source the Variables from files
+if [ -z "${SATELLITE_HOSTNAME}" ]; then
+    source config/compute_resources.conf
+    source config/sat6_upgrade.conf
+fi
+export SATELLITE_VERSION="${TO_VERSION}"
+source config/sat6_repos_urls.conf
+source config/subscription_config.conf
+
+
+# Export required Environment variables for Downstream job
+# As code in Automation Tools understands its Downstream :)
+if [ "${DISTRIBUTION}" = 'DOWNSTREAM' ]; then
+    export BASE_URL="${SATELLITE6_REPO}"
+fi
+
+# Customer DB Setup
+if [ "${CUSTOMERDB_NAME}" != 'NoDB' ]; then
+    source config/preupgrade_entities.conf
+    if [ -n "${SATELLITE_HOSTNAME}" ]; then
+        INSTANCE_NAME="${SATELLITE_HOSTNAME}"
+    elif [ -z "${SATELLITE_HOSTNAME}" ]; then
+        RHEV_INSTANCE_NAME="${CUSTOMERDB_NAME}_customerdb_instance"
+        # Delete  if an instance with same name is already there in rhevm
+        fab -u root delete_rhevm_instance:"${RHEV_INSTANCE_NAME}"
+        # Create a RHEV instance of RHEL6/7 with given template, datacenter, quota and cluster
+        fab -u root create_rhevm_instance:"${RHEV_INSTANCE_NAME}","custdb-${OS}-base",'SAT-QE','SAT-QE','SAT-QE'
+        # To get the value of SAT_INSTANCE_FQDN variable
+        source /tmp/rhev_instance.txt
+        INSTANCE_NAME="${SAT_INSTANCE_FQDN}"
+    fi
+    # This check is because currently Migration changes are in master branch of Satellite-clone.
+    # We may remove this check later w/ next stable release of satellite-clone
+    if [ "${RHEL_MIGRATION}" = "true" ]; then
+        git clone https://github.com/RedHatSatellite/satellite-clone.git
+    else
+        # Clone the 'satellite-clone' w/ tag 1.0.1 that includes the ansible playbook to install sat server along with customer DB.
+        git clone -b 1.0.1 --single-branch --depth 1 https://github.com/RedHatSatellite/satellite-clone.git
+    fi
+    pushd satellite-clone
+    # Copy the inventory.sample to inventory
+    cp -a inventory.sample inventory
+    # Copy the satellite-clone-vars.sample.yml to satellite-clone-vars.yml
+    cp -a satellite-clone-vars.sample.yml satellite-clone-vars.yml
+    # Configuration Updates in inventory file
+    sed -i -e 2s/.*/"${INSTANCE_NAME}"/ inventory
+    # Define  Backup directory for customer DB 
+    BACKUP_DIR="\/var\/tmp\/backup"
+    # Prepare Customer DB URL
+    if [ "${CUSTOMERDB_NAME}" = 'Lidl' ]; then
+        DB_URL="http://"${cust_db_server}"/pub/customer-databases/lidl"
+    elif [ "${CUSTOMERDB_NAME}" = 'ExpressScripts' ]; then
+        DB_URL="http://"${cust_db_server}"/pub/customer-databases/express-scripts/6.2-NOV-28-2016"
+    elif [ "${CUSTOMERDB_NAME}" = 'Sat62RHEL6Migrate' ]; then
+        DB_URL="http://"${cust_db_server}"/pub/qe/sat62-rhel6-db"
+    fi
+    # Configuration updates in vars file
+    sed -i -e "s/^satellite_version.*/satellite_version: "${FROM_VERSION}"/" satellite-clone-vars.yml
+    sed -i -e "s/^activationkey.*/activationkey: "test_ak"/" satellite-clone-vars.yml
+    sed -i -e "s/^org.*/org: "Default\ Organization"/" satellite-clone-vars.yml
+    sed -i -e "s/^#backup_dir.*/backup_dir: "${BACKUP_DIR}"/" satellite-clone-vars.yml
+    sed -i -e "s/^#include_pulp_data.*/include_pulp_data: "${INCLUDE_PULP_DATA}"/" satellite-clone-vars.yml
+    # Note: Statements related to RHN_POOLID, RHN_PASSWORD, RHN_USERNAME and OS_VERSION added to support satellite6 upgrade through CDN
+    # There are no such variables defined in satellite-clone-vars-sample.yaml
+    sed -i -e "/org.*/arhn_pool: "${RHN_POOLID}"" satellite-clone-vars.yml
+    sed -i -e "/org.*/arhn_password: "${RHN_PASSWORD}"" satellite-clone-vars.yml
+    sed -i -e "/org.*/arhn_user: "${RHN_USERNAME}"" satellite-clone-vars.yml
+    sed -i -e "/org.*/arhelversion: "${OS_VERSION}"" satellite-clone-vars.yml
+    # Set the flag true in case of migrating the rhel6 satellite server to rhel7 machine
+    if [ ${RHEL_MIGRATION} = "true" ]; then
+        sed -i -e "s/^#rhel_migration.*/rhel_migration: "${RHEL_MIGRATION}"/" satellite-clone-vars.yml
+        ssh -o "StrictHostKeyChecking no" root@"${INSTANCE_NAME}" "mkdir -p "${BACKUP_DIR}"; wget -q -P /var/tmp/backup -nd -r -l1 --no-parent -A '*.dump' "${DB_URL}""
+        sed -i -e "s/^rhelversion.*/rhelversion: 7/" satellite-clone-vars.yml
+    fi
+    # Configuration updates in tasks file wrt vars file
+    sed -i -e '/subscription-manager register.*/d' roles/satellite-clone/tasks/main.yml
+    sed -i -e '/register host.*/a\ \ command: subscription-manager register --force --user={{ rhn_user }} --password={{ rhn_password }} --release={{ rhelversion }}Server' roles/satellite-clone/tasks/main.yml
+    sed -i -e '/subscription-manager register.*/a- name: subscribe machine' roles/satellite-clone/tasks/main.yml
+    sed -i -e '/subscribe machine.*/a\ \ command: subscription-manager subscribe --pool={{ rhn_pool }}' roles/satellite-clone/tasks/main.yml
+    # Download the Customer DB data Backup files
+    echo "Downloading Customer Data DB's from Server, This may take while depending on the network ....."
+    ssh -o "StrictHostKeyChecking no" root@"${INSTANCE_NAME}" "mkdir -p "${BACKUP_DIR}"; wget -q -P /var/tmp/backup -nd -r -l1 --no-parent -A '*.tar.gz' "${DB_URL}"" 
+    # Run Ansible command to install satellite with cust DB
+    export ANSIBLE_HOST_KEY_CHECKING=False
+    ansible all -i inventory -m ping -u root
+    ansible-playbook -i inventory satellite-clone-playbook.yml
+    # Return to the parent directory
+    popd
+fi
+
+# Run satellite upgrade only when PERORM_UPGRADE flag is set.
+if [ "${PERFORM_UPGRADE}" = "true" ]; then
+    # Run upgrade for CDN/Downstream
+    fab -u root product_upgrade:"${UPGRADE_PRODUCT}"
+    # Post Upgrade archive logs from log analyzer tool
+    if [ -d upgrade-diff-logs ]; then
+        tar -czf Log_Analyzer_Logs.tar.xz upgrade-diff-logs
+    fi
+fi


### PR DESCRIPTION
- Defined a separate standalone job for customer DB upgrade and migration through satellite-clone.
- There are two reasons:
   a) Satellite-upgrader job is becoming more complex w/ more options and features and it has other fields too for capsule and client upgrade.
   b) By keeping it separate, the `Satellite-upgrader` will be  specifically used to perform upgrade w/ rhev instances or w/ user provided satellites.

I used existing `satellite6 upgrader` jobs and make slight changes to create new Satellite6 customer DB upgrade job w/ support of migration. 
 
Note: I just ran `jenkins-jobs` test cmd to test the yaml, however a complete testing is still required. Once this job will be in place, I'll remove customer DB stuff from satellite6-upgrader job.