### PR TITLE
Run nightly every 2 days except Saturdays

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -673,7 +673,7 @@
             name: SATELLITE_DISTRIBUTION
             default: 'UPSTREAM'
     triggers:
-        - timed: 'H 19 * * */2'
+        - timed: 'H 19 * * 0,2,4'
     builders:
         - shell:
             echo "BUILD_LABEL=Upstream Nightly-$(date +%Y-%m-%d)" > properties.txt


### PR DESCRIPTION
It was still causing conflicts though once a week:
```*/2``` = 0(sun), 2(tue), 4(thu), 6(sat) < oops: sun and sat is just 1day

If we say:
```0,2,4``` = 0(sun), 2(tue), 4(thu) 
the automation results then will be consumed on Mon, Wed, Fri. 
And that's perfect.