### PR TITLE
Fix migration as there is no inventory.sample in clone master

### DIFF
--- a/scripts/satellite6_db_upgrade_migrate.sh
+++ b/scripts/satellite6_db_upgrade_migrate.sh
@@ -39,13 +39,14 @@ if [ "${CUSTOMERDB_NAME}" != 'NoDB' ]; then
     # We may remove this check later w/ next stable release of satellite-clone
     if [ "${RHEL_MIGRATION}" = "true" ]; then
         git clone https://github.com/RedHatSatellite/satellite-clone.git
+        pushd satellite-clone
     else
         # Clone the 'satellite-clone' w/ tag 1.0.1 that includes the ansible playbook to install sat server along with customer DB.
         git clone -b 1.0.1 --single-branch --depth 1 https://github.com/RedHatSatellite/satellite-clone.git
+        pushd satellite-clone
+        # Copy the inventory.sample to inventory
+        cp -a inventory.sample inventory
     fi
-    pushd satellite-clone
-    # Copy the inventory.sample to inventory
-    cp -a inventory.sample inventory
     # Copy the satellite-clone-vars.sample.yml to satellite-clone-vars.yml
     cp -a satellite-clone-vars.sample.yml satellite-clone-vars.yml
     # Configuration Updates in inventory file


### PR DESCRIPTION
Migration from clone master doesn't work due to recent changes in file names like:
- there is no inventory.sample in master so when running migration we should not run `cp -a inventory.sample inventory`