### PR TITLE
n-1 satellite and capsule upgrade support added

### DIFF
--- a/jobs/satellite6-upgrader.yaml
+++ b/jobs/satellite6-upgrader.yaml
@@ -24,11 +24,13 @@
                 - capsule
                 - client
                 - longrun
+                - n-1
             description: |
                 <p>Select 'satellite' to perform only <b>Satellite</b>upgrade</p>
                 <p>Select 'capsule' to perform both <b>Capsule as well as its associated Satellite</b>upgrade</p>
                 <p>Select 'client' to perform <b>Clients as well as its associated Satellite</b>upgrade</p>
                 <p>Select 'longrun' to perform <b>Satellite, Capsule and Clients</b>upgrade</p>
+                <p>Select 'n-1' to perform only satellite upgrade, by keeping capsule at last released zStream version.</p>
         - choice:
             name: FROM_VERSION
             choices:


### PR DESCRIPTION
The PR includes:

'n-1' capsule upgrade with satellite at 'n' version. 

Basically its like 'satellite' at latest downstream(zStream) and 'capsule' at released zStream.