### PR TITLE
added downstream_nightly as satellite version choice

### DIFF
--- a/jobs/satellite6-libvirt-install.yaml
+++ b/jobs/satellite6-libvirt-install.yaml
@@ -43,6 +43,7 @@
                 - '6.2'
                 - '6.1'
                 - '6.0'
+                - 'downstream-nightly'
         - choice:
             name: DISTRO
             choices:


### PR DESCRIPTION
updated `downstream_nightly` as satellite version for `satellite6_libvirt_install` job 