### PR TITLE
Fix Upgrade Trigger Job with refactored automations tools code

### DIFF
--- a/scripts/satellite6-upgrade-trigger.sh
+++ b/scripts/satellite6-upgrade-trigger.sh
@@ -54,5 +54,10 @@ if [ "${{TO_VERSION}}" = '6.1' ]; then
     exit 1
 fi
 
+# Sets up the satellite, capsule and clients on rhevm or personal boxes before upgrading
+fab -u root setup_products_for_upgrade:'longrun',"{os}"
+
 # Longrun to run upgrade on Satellite, capsule and clients
 fab -u root product_upgrade:'longrun'
+
+


### PR DESCRIPTION
The earlier product_upgrade() function in automation tools is now split into two functions, i.e:
The setup part & Upgrade part

The intention is to run some tasks, tests after setup and before upgrade.
The trigger job was failing due to this change, this PR should fix that.