### PR TITLE
manifest-downloader - modified schedule (every 2 days)

### DIFF
--- a/jobs/satellite6-manifest-downloader.yaml
+++ b/jobs/satellite6-manifest-downloader.yaml
@@ -5,7 +5,7 @@
     description: |
         Downloads the Satellite6 Manifest from access.redhat.com
     triggers:
-        - timed: '00 17 * * 0'
+        - timed: 'H 17 * * 0,2,4'
     node: sat6-rhel7
     scm:
         - git:


### PR DESCRIPTION
looks like refreshing manifest on a weekly basis is not sufficient any longer. Let's run it every 2 days. It typically takes few seconds to complete, so there should be no harm done.