### PR TITLE
Destructive job run configured to run without parallel execution.

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -398,10 +398,6 @@
             project: 'automation-{satellite_version}-tier4-{os}'
             filter: '*-results.xml'
             which-build: last-successful
-        - copyartifact:
-            project: 'automation-{satellite_version}-destructive-{os}'
-            filter: '*-results.xml'
-            which-build: last-successful
         - shining-panda:
             build-environment: virtualenv
             python-version: System-CPython-2.7

--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -50,7 +50,7 @@ if [[ "${SATELLITE_DISTRIBUTION}" != *"GA"* ]]; then
     sed -i "s|capsule_repo.*|capsule_repo=${CAPSULE_REPO}|" robottelo.properties
 fi
 
-if [ "${ENDPOINT}" != "rhai" ]; then
+if [ "${ENDPOINT}" != "rhai" || "${ENDPOINT}" != "destructive" ]; then
     set +e
     # Run parallel tests
     $(which py.test) -v --junit-xml="${ENDPOINT}-parallel-results.xml" -n "${ROBOTTELO_WORKERS}" \


### PR DESCRIPTION
Also currently the job may fail as there are no tests marked to
be run as destructive tests. Once we have few tests marked and
automated as destructive tests they can be enabled to be part of
an automation-report.