### PR TITLE
Betelgeuse jobs need to checkout the correct branch from Robottelo

### DIFF
--- a/jobs/satellite6-betelgeuse.yaml
+++ b/jobs/satellite6-betelgeuse.yaml
@@ -35,7 +35,7 @@
         - git:
             url: https://github.com/SatelliteQE/robottelo.git
             branches:
-                - origin/master
+                - '{scm-branch}'
             skip-tag: true
     properties:
         - satellite6-polarion-build_blocker:


### PR DESCRIPTION
Checked the generated files and it works fine.
```
(rci) [kbid@setup32-91 robottelo-ci]$ for i in `ls /tmp/jobs/polarion-test-run-*`; do  grep -A 4 "<branches>" $i; done
/tmp/jobs/polarion-test-run-6.1-rhel6
    <branches>
      <hudson.plugins.git.BranchSpec>
        <name>origin/6.1.z</name>
      </hudson.plugins.git.BranchSpec>
    </branches>
/tmp/jobs/polarion-test-run-6.1-rhel7
    <branches>
      <hudson.plugins.git.BranchSpec>
        <name>origin/6.1.z</name>
      </hudson.plugins.git.BranchSpec>
    </branches>
/tmp/jobs/polarion-test-run-6.2-rhel6
    <branches>
      <hudson.plugins.git.BranchSpec>
        <name>origin/6.2.z</name>
      </hudson.plugins.git.BranchSpec>
    </branches>
/tmp/jobs/polarion-test-run-6.2-rhel7
    <branches>
      <hudson.plugins.git.BranchSpec>
        <name>origin/6.2.z</name>
      </hudson.plugins.git.BranchSpec>
    </branches>
/tmp/jobs/polarion-test-run-6.3-rhel6
    <branches>
      <hudson.plugins.git.BranchSpec>
        <name>origin/master</name>
      </hudson.plugins.git.BranchSpec>
    </branches>
/tmp/jobs/polarion-test-run-6.3-rhel7
    <branches>
      <hudson.plugins.git.BranchSpec>
        <name>origin/master</name>
      </hudson.plugins.git.BranchSpec>
    </branches>
/tmp/jobs/polarion-test-run-downstream-nightly-rhel6
    <branches>
      <hudson.plugins.git.BranchSpec>
        <name>origin/master</name>
      </hudson.plugins.git.BranchSpec>
    </branches>
/tmp/jobs/polarion-test-run-downstream-nightly-rhel7
    <branches>
      <hudson.plugins.git.BranchSpec>
        <name>origin/master</name>
      </hudson.plugins.git.BranchSpec>
    </branches>
/tmp/jobs/polarion-test-run-upstream-nightly-rhel6
    <branches>
      <hudson.plugins.git.BranchSpec>
        <name>origin/master</name>
      </hudson.plugins.git.BranchSpec>
    </branches>
/tmp/jobs/polarion-test-run-upstream-nightly-rhel7
    <branches>
      <hudson.plugins.git.BranchSpec>
        <name>origin/master</name>
      </hudson.plugins.git.BranchSpec>
    </branches>

```