### PR TITLE
only mangle the `gem 'something'` lines in the Gemfile

### DIFF
--- a/scripts/test_smart_proxy_plugins.sh
+++ b/scripts/test_smart_proxy_plugins.sh
@@ -7,7 +7,7 @@ rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 gem install bundler --no-ri --no-rdoc
 
-sed -e '/smart_proxy/ s/^#*/#/' -i Gemfile
+sed -e '/gem .*smart_proxy/ s/^#*/#/' -i Gemfile
 
 echo "gem 'smart_proxy', :git => 'https://${GIT_HOSTNAME}/${GIT_ORGANIZATION}/smart-proxy.git', :ref => '${gitlabTargetBranch}'" > Gemfile.local.rb
 


### PR DESCRIPTION
previously the sed line would also kill lines like this:

    gemspec :name => 'smart_proxy_dynflow_core'

however, this means that bundler does not pick up any deps from the gemspec, which leads to funny errors during builds/tests because simple gems like rake, rubocop or mocha cannot be found.