### PR TITLE
 betelgeuse version and commands depend upon satellite_version

### DIFF
--- a/jobs/satellite6-betelgeuse.yaml
+++ b/jobs/satellite6-betelgeuse.yaml
@@ -21,7 +21,7 @@
             nature: shell
             command:
                 !include-raw:
-                    - scripts/satellite6-betelgeuse.sh
+                    - scripts/satellite6-install-pylarion.sh
                     - scripts/satellite6-betelgeuse-test-case.sh
     publishers:
         - satellite6-automation-mails
@@ -55,6 +55,9 @@
             mask-password-params: true
         - build-name:
             name: '#${{BUILD_NUMBER}} ${{ENV,var="TEST_RUN_ID"}}'
+        - inject:
+            properties-content: |
+                SATELLITE_VERSION={satellite_version}
     builders:
         - copyartifact:
             project: automation-{satellite_version}-tier1-{os}
@@ -80,7 +83,7 @@
             nature: shell
             command:
                 !include-raw-escape:
-                    - scripts/satellite6-betelgeuse.sh
+                    - scripts/satellite6-install-pylarion.sh
                     - scripts/satellite6-betelgeuse-test-run.sh
     publishers:
         - satellite6-automation-mails

--- a/scripts/satellite6-betelgeuse-test-case.sh
+++ b/scripts/satellite6-betelgeuse-test-case.sh
@@ -1,3 +1,6 @@
+# Install the latest version of betelgeuse.
+pip install betelgeuse
+
 betelgeuse test-case \
     --path tests/foreman \
     --automation-script-format "https://github.com/SatelliteQE/robottelo/blob/master/{path}#L{line_number}" \

--- a/scripts/satellite6-betelgeuse-test-run.sh
+++ b/scripts/satellite6-betelgeuse-test-run.sh
@@ -1,3 +1,12 @@
+# Populate token-prefix and betelgeuse depending upon Satellite6 Version.
+if [[ "${SATELLITE_VERSION}" = "6.1" ]] || [[ "${SATELLITE_VERSION}" = "6.2" ]] ; then
+    pip install "betelgeuse<0.8"
+    TOKEN_PREFIX="--token-prefix \"@\""
+else
+    pip install betelgeuse
+    TOKEN_PREFIX=""
+fi
+
 # Create a new release with POLARION_RELEASE as the parent-plan.
 
 if [ -n "$POLARION_RELEASE" ]; then
@@ -23,7 +32,7 @@ SANITIZED_ITERATION_ID="$(echo ${TEST_RUN_ID} | sed 's|\.|_|g' | sed 's| |_|g')"
 # Prepare the XML files
 for tier in $(seq 1 4); do
    for run in parallel sequential; do
-        betelgeuse xml-test-run \
+        betelgeuse "${TOKEN_PREFIX}" xml-test-run \
             --custom-fields "isautomated=true" \
             --custom-fields "arch=x8664" \
             --custom-fields "variant=server" \

--- a/scripts/satellite6-install-pylarion.sh
+++ b/scripts/satellite6-install-pylarion.sh
@@ -7,5 +7,3 @@ git checkout origin/satelliteqe-pylarion
 pip install -r requirements.txt
 pip install .
 cd ..
-
-pip install betelgeuse


### PR DESCRIPTION
a) Depending upon the satellite_version the betelgeuse version is
   used for only satellite6-betelgeuse-test-run job.
b) For satellite_version 6.1 and 6.2 the betelgeuse version is
   '<0.8'. The exact betelgeuse version would be 0.7.1.
c) For satellite_version 6.3, downstream-nightly and
   upstream-nightly the betelgeuse version would be the latest.
d) These changes would help using betelgeuse with --token-prefix
   command depending upon the satellite version.
e) Also satellite6-betelgeuse.sh script is renamed as now it only
   does the installtion of pylarion. As at this stage the
   betelgeuse-test-case job has no way of knowing the
   satellite_version to install the correct betelgeuse version.
f) Installing betelgeuse is now moved to at a later stage,
   as satellite_version is only required for the,
   satellite6-betelgeuse-test-run job and not for the,
   satellite6-betelgeuse-test-case job, which requires only the
   latest version of betelgeuse.