### PR TITLE
allow overriding GitLab parameters via job params

### DIFF
--- a/jobs/parameters/merge_request.yaml
+++ b/jobs/parameters/merge_request.yaml
@@ -2,14 +2,14 @@
     name: merge_request
     parameters:
       - string:
-          name: gitlabSourceRepoName
+          name: sourceRepoName
           default: 
           description: 'Source repository name (e.g. ehelms/foreman)'
       - string:
-          name: gitlabSourceBranch
+          name: sourceBranch
           default: 
           description: 'Source repository branch where the change exists (e.g. my-bug-branch)'
       - string:
-          name: gitlabTargetBranch
+          name: targetBranch
           default: 
           description: 'Branch on the target repository that the merge request is going into (e.g. master)'

--- a/jobs/properties/gitlab_variables.yaml
+++ b/jobs/properties/gitlab_variables.yaml
@@ -1,0 +1,8 @@
+- property:
+    name: gitlab_variables
+    properties:
+        - inject:
+              groovy-content: |
+                  if (!binding.variables.containsKey('gitlabSourceBranch')) {
+                      return ["gitlabSourceBranch": "$sourceBranch", "gitlabTargetBranch": "$targetBranch", "gitlabSourceRepoName": "$sourceRepoName"]
+                  }

--- a/jobs/unittest/satellite6-unit-test-bastion.yaml
+++ b/jobs/unittest/satellite6-unit-test-bastion.yaml
@@ -5,6 +5,8 @@
       numToKeep: 32
     concurrent: true
     node: rhel
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-dynflow.yaml
+++ b/jobs/unittest/satellite6-unit-test-dynflow.yaml
@@ -5,6 +5,8 @@
       daysToKeep: -1
       numToKeep: 32
     concurrent: true
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-foreman-bootdisk.yaml
+++ b/jobs/unittest/satellite6-unit-test-foreman-bootdisk.yaml
@@ -4,6 +4,8 @@
       daysToKeep: -1
       numToKeep: 32
     node: rhel
+    properties:
+      - gitlab_variables
     parameters:
       - ruby
       - database

--- a/jobs/unittest/satellite6-unit-test-foreman-discovery.yaml
+++ b/jobs/unittest/satellite6-unit-test-foreman-discovery.yaml
@@ -4,6 +4,8 @@
       daysToKeep: -1
       numToKeep: 32
     node: rhel
+    properties:
+      - gitlab_variables
     parameters:
       - ruby
       - database

--- a/jobs/unittest/satellite6-unit-test-foreman-docker.yaml
+++ b/jobs/unittest/satellite6-unit-test-foreman-docker.yaml
@@ -5,6 +5,8 @@
       numToKeep: 32
     node: rhel
     concurrent: true
+    properties:
+      - gitlab_variables
     parameters:
       - ruby
       - database

--- a/jobs/unittest/satellite6-unit-test-foreman-openscap.yaml
+++ b/jobs/unittest/satellite6-unit-test-foreman-openscap.yaml
@@ -4,6 +4,8 @@
       daysToKeep: -1
       numToKeep: 32
     node: rhel
+    properties:
+      - gitlab_variables
     parameters:
       - ruby
       - database

--- a/jobs/unittest/satellite6-unit-test-foreman-remote-execution.yaml
+++ b/jobs/unittest/satellite6-unit-test-foreman-remote-execution.yaml
@@ -4,6 +4,8 @@
       daysToKeep: -1
       numToKeep: 32
     node: rhel
+    properties:
+      - gitlab_variables
     parameters:
       - ruby
       - database

--- a/jobs/unittest/satellite6-unit-test-foreman-tasks.yaml
+++ b/jobs/unittest/satellite6-unit-test-foreman-tasks.yaml
@@ -4,6 +4,8 @@
       daysToKeep: -1
       numToKeep: 32
     node: rhel
+    properties:
+      - gitlab_variables
     parameters:
       - ruby
       - database

--- a/jobs/unittest/satellite6-unit-test-foreman.yaml
+++ b/jobs/unittest/satellite6-unit-test-foreman.yaml
@@ -5,6 +5,8 @@
       numToKeep: 32
     node: rhel
     concurrent: true
+    properties:
+      - gitlab_variables
     parameters:
       - ruby
       - database

--- a/jobs/unittest/satellite6-unit-test-hammer-cli-foreman-discovery.yaml
+++ b/jobs/unittest/satellite6-unit-test-hammer-cli-foreman-discovery.yaml
@@ -5,6 +5,8 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 32
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-hammer-cli-foreman-remote-execution.yaml
+++ b/jobs/unittest/satellite6-unit-test-hammer-cli-foreman-remote-execution.yaml
@@ -5,6 +5,8 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 32
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-hammer-cli-foreman.yaml
+++ b/jobs/unittest/satellite6-unit-test-hammer-cli-foreman.yaml
@@ -5,6 +5,8 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 32
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-hammer-cli-katello.yaml
+++ b/jobs/unittest/satellite6-unit-test-hammer-cli-katello.yaml
@@ -5,6 +5,8 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 32
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-hammer-cli.yaml
+++ b/jobs/unittest/satellite6-unit-test-hammer-cli.yaml
@@ -5,6 +5,8 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 32
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-kafo.yaml
+++ b/jobs/unittest/satellite6-unit-test-kafo.yaml
@@ -5,6 +5,8 @@
       daysToKeep: -1
       numToKeep: 32
     concurrent: true
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-katello.yaml
+++ b/jobs/unittest/satellite6-unit-test-katello.yaml
@@ -4,6 +4,8 @@
       daysToKeep: -1
       numToKeep: 32
     node: rhel
+    properties:
+      - gitlab_variables
     parameters:
       - ruby
       - database

--- a/jobs/unittest/satellite6-unit-test-puppet-capsule.yaml
+++ b/jobs/unittest/satellite6-unit-test-puppet-capsule.yaml
@@ -5,6 +5,8 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 16
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-puppet-certs.yaml
+++ b/jobs/unittest/satellite6-unit-test-puppet-certs.yaml
@@ -5,6 +5,8 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 16
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-puppet-foreman-proxy.yaml
+++ b/jobs/unittest/satellite6-unit-test-puppet-foreman-proxy.yaml
@@ -5,6 +5,8 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 16
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-puppet-foreman.yaml
+++ b/jobs/unittest/satellite6-unit-test-puppet-foreman.yaml
@@ -5,6 +5,8 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 16
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-puppet-katello.yaml
+++ b/jobs/unittest/satellite6-unit-test-puppet-katello.yaml
@@ -5,6 +5,8 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 16
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-puppet-pulp.yaml
+++ b/jobs/unittest/satellite6-unit-test-puppet-pulp.yaml
@@ -5,6 +5,8 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 16
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-puppet-puppet.yaml
+++ b/jobs/unittest/satellite6-unit-test-puppet-puppet.yaml
@@ -5,6 +5,8 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 16
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-smart-proxy-dynflow.yaml
+++ b/jobs/unittest/satellite6-unit-test-smart-proxy-dynflow.yaml
@@ -5,6 +5,8 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 16
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-smart-proxy-openscap.yaml
+++ b/jobs/unittest/satellite6-unit-test-smart-proxy-openscap.yaml
@@ -5,6 +5,8 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 16
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-smart-proxy-remote-execution-ssh.yaml
+++ b/jobs/unittest/satellite6-unit-test-smart-proxy-remote-execution-ssh.yaml
@@ -4,6 +4,8 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 16
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-smart-proxy.yaml
+++ b/jobs/unittest/satellite6-unit-test-smart-proxy.yaml
@@ -4,6 +4,8 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 16
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-test-repo.yaml
+++ b/jobs/unittest/satellite6-unit-test-test-repo.yaml
@@ -5,6 +5,8 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 32
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-tool-belt.yaml
+++ b/jobs/unittest/satellite6-unit-test-tool-belt.yaml
@@ -4,6 +4,8 @@
     logrotate:
       daysToKeep: -1
       numToKeep: 32
+    properties:
+      - gitlab_variables
     parameters:
       - merge_request
     scm:


### PR DESCRIPTION
Since GitLab plugin 1.2 we can't directly override stuff via job parameters, because the plugin does not generate parameters for us.

* drop the gitlab prefix from the parameters (otherwise it confuses with the env vars GitLab sets)
* if the GitLab env vars are not set (= we have a manually triggered job) set the right vars from the parameters provided