### PR TITLE
Fixed the upgrade clean-up job , to clean docker clinets

### DIFF
--- a/jobs/satellite6-upgrade-cleanup.yaml
+++ b/jobs/satellite6-upgrade-cleanup.yaml
@@ -15,6 +15,11 @@
             wipe-workspace: true
     triggers:
         - timed: 'H 0 * * 7'
+    wrappers:
+        - config-file-provider:
+            files:
+                - file-id: bc5f0cbc-616f-46de-bdfe-2e024e84fcbf
+                  variable: CONFIG_FILES
     builders:
           - shining-panda:
               build-environment: virtualenv


### PR DESCRIPTION
The Clean job was failing , due to missing config file , wrapping and wasn't exporting the required variables.

> [satellite6-upgrade-cleanup] $ /bin/sh -xe /tmp/shiningpanda2110223026271041798.sh
source
/tmp/shiningpanda2110223026271041798.sh: line 3: source: filename argument required