### PR TITLE
Fixes the pycurl libcurl issue, for the satellite6-upgrade-cleanup

### DIFF
--- a/jobs/satellite6-upgrade-cleanup.yaml
+++ b/jobs/satellite6-upgrade-cleanup.yaml
@@ -28,4 +28,5 @@
               nature: shell
               command:
                 !include-raw:
+                    - 'pip-install-pycurl.sh'
                     - 'satellite6-upgrade-cleanup.sh'


### PR DESCRIPTION
Error:

> from ovirtsdk.infrastructure.connectionspool import ConnectionsPool
> File "/home/jenkins/shiningpanda/jobs/de248335/virtualenvs/d41d8cd9/lib/python2.7/site-packages/ovirtsdk/infrastructure/connectionspool.py", line 18, in <module>
> import pycurl
> ImportError: pycurl: libcurl link-time ssl backend (nss) is different from compile-time ssl backend (none/other)