### PR TITLE
Added publisher to subproject job existence-tests and fixes run on error

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -621,6 +621,8 @@
                 BUILD_LABEL=${{BUILD_LABEL}}
                 DISCOVERY_ISO=${{DISCOVERY_ISO}}
                 ROBOTTELO_WORKERS=${{ROBOTTELO_WORKERS}}
+    publishers:
+        - satellite6-automation-publishers
 
 - job-template:
     disabled: false

--- a/scripts/satellite6-upgrade-existence.sh
+++ b/scripts/satellite6-upgrade-existence.sh
@@ -1,4 +1,15 @@
 # Setting Prerequisites
 pip install -r requirements.txt
-
+set +e
 $(which py.test) -v --continue-on-collection-errors --junit-xml=test_existance-results.xml upgrade_tests/test_existance_relations/
+set -e
+
+echo
+echo "========================================"
+echo "Server information"
+echo "========================================"
+echo "Hostname: $SERVER_HOSTNAME"
+echo "Credentials: admin/changeme"
+echo "========================================"
+echo
+echo "========================================"


### PR DESCRIPTION
1) Publisher added to the job , to get the test results
2) Also, now the sub-project will be triggered , even if the test-cases has failures