### PR TITLE
Fixes the upgrade test tier jobs, by exporting only necessary variables

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -659,7 +659,7 @@
            nature: shell
            command:
                !include-raw-escape:
-                   - 'satellite6-upgrade-source.sh'
+                   - 'satellite6-upgrade-tier-source.sh'
                    - 'satellite6-automation.sh'
                    - 'satellite6-foreman-debug.sh'
         - trigger-builds:
@@ -705,7 +705,7 @@
            nature: shell
            command:
                !include-raw-escape:
-                   - 'satellite6-upgrade-source.sh'
+                   - 'satellite6-upgrade-tier-source.sh'
                    - 'satellite6-automation.sh'
                    - 'satellite6-foreman-debug.sh'
     publishers:

--- a/scripts/satellite6-upgrade-source.sh
+++ b/scripts/satellite6-upgrade-source.sh
@@ -33,7 +33,6 @@ source config/sat6_upgrade.conf
 source config/sat6_repos_urls.conf
 source config/subscription_config.conf
 source config/fake_manifest.conf
-export SERVER_HOSTNAME="${{RHEV_SAT_HOST}}"
 
 # Fetching correct BASE_URL and CAPSULE_URL
 export BASE_URL="${{SATELLITE6_REPO}}"

--- a/scripts/satellite6-upgrade-tier-source.sh
+++ b/scripts/satellite6-upgrade-tier-source.sh
@@ -1,0 +1,5 @@
+ # Sourcing and exporting required env vars for tier jobs
+source ${CONFIG_FILES}
+source config/compute_resources.conf
+source config/sat6_upgrade.conf
+export SERVER_HOSTNAME="${SERVER_HOSTNAME:-${RHEV_SAT_HOST}}"


### PR DESCRIPTION
This will fix the issue , where only necessary variables will be sourced.
This problem was due to aggregating same code from upgrade-trigger.sh and existence.sh into upgrade-source.sh.
So , now upgrade-source.sh , contained unnecessary variables , not required by tier jobs.
This PR aims at solving the problem, by adding a new upgrade-tier-source.sh into the tier jobs to source variables in tier jobs.