### PR TITLE
Add option to specify more custom_repos as space-separated list

### DIFF
--- a/jobs/parameters/satellite6_provisioning_parameters.yaml
+++ b/jobs/parameters/satellite6_provisioning_parameters.yaml
@@ -39,9 +39,10 @@
                 however, in case of CUSTOM hotfix should be in the form of hotfix_rhel6.sh hotfix_rhel7.sh scripts.
                 These files should be placed in the above mentioned format only, at http://sat6-rhel6/pub/hotfix/ path.
         - string:
-            name: OS_UPGRADE_REPO
+            name: OS_UPGRADE_REPOS
             description: |
-                Upgrade OS using this repo URL, typically RHEL candidate repo.
+                Upgrade OS using this repo URL(s), typically RHEL candidate repo.
+                This can be space-separated list of repos' URLs to specify multiple repos.
         - bool:
             name: PUPPET4
             default: false

--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -118,9 +118,10 @@
                 Do not specify these installer options related to (Interface, Gateway, DNS, DHCP, TFTP, PUPPET)
                 here, these are already handled.
         - string:
-            name: OS_UPGRADE_REPO
+            name: OS_UPGRADE_REPOS
             description: |
-                Upgrade OS using this repo URL, typically RHEL candidate repo.
+                Upgrade OS using this repo URL(s), typically RHEL candidate repo.
+                This can be space-separated list of repos' URLs to specify multiple repos.
         - bool:
             name: PUPPET4
             default: false


### PR DESCRIPTION
- rename OS_UPGRADE_REPO to OS_UPGRADE_REPOS as it can be also space separated list
- update param description


(Fixes #649)