### PR TITLE
Restrict the slave node for closed loop job

### DIFF
--- a/jobs/satellite6-closed-loop.yaml
+++ b/jobs/satellite6-closed-loop.yaml
@@ -1,7 +1,8 @@
 - job:
     disabled: false
     name: satellite6-closed-loop
-    concurrent: false 
+    node: sat6-rhel6
+    concurrent: false
     description: |
         <p>Job that runs closed loop process</p>
     scm:


### PR DESCRIPTION
A new slave node was introduced yesterday to jenkins yesterday.  closed-loop ran on this node which does not have proper setup for the job.  So I am restricting this job to run on a specific slave.