### PR TITLE
fixed the sed cmd by changing delimiter

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -11,7 +11,7 @@ sed -i "s/# bz_username=.*/bz_username=${BUGZILLA_USER}/" robottelo.properties
 # AWS Access Keys Configuration
 
 sed -i "s/# access_key=.*/access_key=${AWS_ACCESSKEY_ID}/" robottelo.properties
-sed -i "s/# secret_key=.*/secret_key=${AWS_ACCESSKEY_SECRET}/" robottelo.properties
+sed -i "s|# secret_key=.*|secret_key=${AWS_ACCESSKEY_SECRET}|" robottelo.properties
 
 # Robottelo Capsule Configuration
 


### PR DESCRIPTION
```
+ sed -i 's/# secret_key=.*/secret_key=[*******]/' robottelo.properties
sed: -e expression #1, char 65: unknown option to `s'
```