### PR TITLE
installing six python module explicitly

### DIFF
--- a/scripts/pip-install-pycurl.sh
+++ b/scripts/pip-install-pycurl.sh
@@ -1,4 +1,5 @@
 pip install -U pip
+pip install six
 
 if [ "$(curl --version | grep NSS 2>/dev/null)" ]; then
     pip install --compile --install-option="--with-nss" pycurl


### PR DESCRIPTION
To fix the issue related to `ImportError: No module named six` 