### PR TITLE
Running the upgrade cleanup job every 2 days to clean containers

### DIFF
--- a/jobs/satellite6-upgrade-cleanup.yaml
+++ b/jobs/satellite6-upgrade-cleanup.yaml
@@ -14,7 +14,7 @@
             skip-tag: true
             wipe-workspace: true
     triggers:
-        - timed: 'H 0 * * 7'
+        - timed: 'H 17 * * 0,2,4'
     wrappers:
         - config-file-provider:
             files:


### PR DESCRIPTION
This will run the job every 2 days , this job only deletes containers that are older than a day