### PR TITLE
Copy artifacts from test-run's upstream jobs

### DIFF
--- a/jobs/satellite6-betelgeuse.yaml
+++ b/jobs/satellite6-betelgeuse.yaml
@@ -69,19 +69,19 @@
         - copyartifact:
             project: automation-{satellite_version}-tier1-{os}
             filter: '*-results.xml'
-            which-build: last-completed
+            which-build: upstream-build
         - copyartifact:
             project: automation-{satellite_version}-tier2-{os}
             filter: '*-results.xml'
-            which-build: last-completed
+            which-build: upstream-build
         - copyartifact:
             project: automation-{satellite_version}-tier3-{os}
             filter: '*-results.xml'
-            which-build: last-completed
+            which-build: upstream-build
         - copyartifact:
             project: automation-{satellite_version}-tier4-{os}
             filter: '*-results.xml'
-            which-build: last-completed
+            which-build: upstream-build
         - shining-panda:
             build-environment: virtualenv
             name: betelgeuse


### PR DESCRIPTION
Copy artifacts from the upstream build that have triggered the test run
job. This will allow rebuilding test run jobs better so it will always
copy from the same upstream jobs' runs.