### PR TITLE
Parameterize ruby and remove matrix job from ohsnap

### DIFF
--- a/jobs/parameters/ruby.yaml
+++ b/jobs/parameters/ruby.yaml
@@ -3,5 +3,5 @@
     parameters:
       - string:
           name: ruby
-          default: '2.2'
+          default: '{version}'
           description: 'Version of Ruby to test against'

--- a/jobs/unittest/satellite6-unit-test-foreman-bootdisk.yaml
+++ b/jobs/unittest/satellite6-unit-test-foreman-bootdisk.yaml
@@ -7,7 +7,8 @@
     properties:
       - gitlab_variables
     parameters:
-      - ruby
+      - ruby:
+        version: '2.2'
       - database
       - merge_request
       - string:

--- a/jobs/unittest/satellite6-unit-test-foreman-discovery.yaml
+++ b/jobs/unittest/satellite6-unit-test-foreman-discovery.yaml
@@ -7,7 +7,8 @@
     properties:
       - gitlab_variables
     parameters:
-      - ruby
+      - ruby:
+        version: '2.2'
       - database
       - merge_request
       - string:

--- a/jobs/unittest/satellite6-unit-test-foreman-docker.yaml
+++ b/jobs/unittest/satellite6-unit-test-foreman-docker.yaml
@@ -8,7 +8,8 @@
     properties:
       - gitlab_variables
     parameters:
-      - ruby
+      - ruby:
+        version: '2.2'
       - database
       - merge_request
       - string:

--- a/jobs/unittest/satellite6-unit-test-foreman-openscap.yaml
+++ b/jobs/unittest/satellite6-unit-test-foreman-openscap.yaml
@@ -7,7 +7,8 @@
     properties:
       - gitlab_variables
     parameters:
-      - ruby
+      - ruby:
+        version: '2.2'
       - database
       - merge_request
       - string:

--- a/jobs/unittest/satellite6-unit-test-foreman-remote-execution.yaml
+++ b/jobs/unittest/satellite6-unit-test-foreman-remote-execution.yaml
@@ -7,7 +7,8 @@
     properties:
       - gitlab_variables
     parameters:
-      - ruby
+      - ruby:
+        version: '2.2'
       - database
       - merge_request
       - string:

--- a/jobs/unittest/satellite6-unit-test-foreman-tasks.yaml
+++ b/jobs/unittest/satellite6-unit-test-foreman-tasks.yaml
@@ -7,7 +7,8 @@
     properties:
       - gitlab_variables
     parameters:
-      - ruby
+      - ruby:
+        version: '2.2'
       - database
       - merge_request
       - string:

--- a/jobs/unittest/satellite6-unit-test-foreman.yaml
+++ b/jobs/unittest/satellite6-unit-test-foreman.yaml
@@ -8,7 +8,8 @@
     properties:
       - gitlab_variables
     parameters:
-      - ruby
+      - ruby:
+        version: '2.2'
       - database
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-katello.yaml
+++ b/jobs/unittest/satellite6-unit-test-katello.yaml
@@ -7,7 +7,8 @@
     properties:
       - gitlab_variables
     parameters:
-      - ruby
+      - ruby:
+        version: '2.2'
       - database
       - merge_request
     scm:

--- a/jobs/unittest/satellite6-unit-test-ohsnap.yaml
+++ b/jobs/unittest/satellite6-unit-test-ohsnap.yaml
@@ -1,7 +1,6 @@
 - job:
     name: satellite6-unit-test-ohsnap
     node: rhel
-    project-type: matrix
     logrotate:
       daysToKeep: -1
       numToKeep: 32
@@ -9,20 +8,10 @@
       - gitlab_variables
     parameters:
       - merge_request
+      - ruby:
+        version: 2.3
     scm:
       - ohsnap_gitlab
-    axes:
-      - axis:
-          type: user-defined
-          name: ruby
-          values:
-            - 1.9.3
-            - 2.3
-      - axis:
-          type: slave
-          name: nodes
-          values:
-            - rhel
     triggers:
       - gitlab_build_on_change
     builders:


### PR DESCRIPTION
Makes Ohsnap testing a normal job testing only Ruby 2.3 by parameterizing the ruby parameter.