### PR TITLE
including syslogs by not skipping the generic info for foreman-debug

### DIFF
--- a/scripts/satellite6-foreman-debug.sh
+++ b/scripts/satellite6-foreman-debug.sh
@@ -6,6 +6,6 @@ fi
 # Disable error checking, for more information check the related issue
 # http://projects.theforeman.org/issues/13442
 set +e
-ssh -o StrictHostKeyChecking=no "root@${SERVER_HOSTNAME}" foreman-debug -g -m 0 -q -d "~/foreman-debug"
+ssh -o StrictHostKeyChecking=no "root@${SERVER_HOSTNAME}" foreman-debug -m 0 -q -d "~/foreman-debug"
 set -e
 scp -o StrictHostKeyChecking=no -r "root@${SERVER_HOSTNAME}:~/foreman-debug.tar.xz" .


### PR DESCRIPTION
```
# foreman-debug -h
...
  -g      Skip generic info (CPU, memory, firewall etc.)
...
```

..this option actually excluded syslog from the list of published files.