### PR TITLE
Fix the zStream existence tests due to wrong from version calculatioon

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -586,6 +586,7 @@
             properties-file: properties.txt
         - trigger-builds:
             - project: 'automation-upgraded-{satellite_version}-existence-tests-{os}'
+              current-parameters: true
               predefined-parameters: |
                 SERVER_HOSTNAME=${{SERVER_HOSTNAME}}
                 TOOLS_REPO=${{TOOLS_REPO}}


### PR DESCRIPTION
Fixes issue #697 
The issue happened due to:
ZSTREAM_UPGRADE param missing in existence tests job script file 'satellite6-upgrade-source.sh'

Fix:
The parameter ZSTREAM_UPGRADE is now passed from upgrade job to its existence tests job.