### PR TITLE
Increase the timeout of ci-subscribe to 3 hours

### DIFF
--- a/jobs/builders/satellite6_testcase_ci_subscribe.yaml
+++ b/jobs/builders/satellite6_testcase_ci_subscribe.yaml
@@ -7,5 +7,5 @@
                   <providerName>default</providerName>
                   <selector>{selector}</selector>
                   <variable>TESTCASE_IMPORT_RESULTS</variable>
-                  <timeout>120</timeout>
+                  <timeout>180</timeout>
                 </com.redhat.jenkins.plugins.ci.CIMessageSubscriberBuilder>


### PR DESCRIPTION
The response message is taking longer and the timeout is happening
before the response message being sent.