### PR TITLE
Use -D (--disable-known-hosts) with fab commands

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -1,7 +1,7 @@
 pip install -U -r requirements.txt
 
 # Figure out what version of RHEL the server uses
-export OS_VERSION=$(fab -H root@${SERVER_HOSTNAME} distro_info | grep "rhel [[:digit:]]" | cut -d ' ' -f 2)
+export OS_VERSION=$(fab -D -H root@${SERVER_HOSTNAME} distro_info | grep "rhel [[:digit:]]" | cut -d ' ' -f 2)
 DISTRO="rhel${OS_VERSION}"
 
 source ${CONFIG_FILES}
@@ -23,11 +23,11 @@ export EXTERNAL_AUTH
 export IDM_REALM
 
 if [ ${FIX_HOSTNAME} = "true" ]; then
-    fab -H root@${SERVER_HOSTNAME} fix_hostname
+    fab -D -H root@${SERVER_HOSTNAME} fix_hostname
 fi
 
 if [ ${PARTITION_DISK} = "true" ]; then
-    fab -H root@${SERVER_HOSTNAME} partition_disk
+    fab -D -H root@${SERVER_HOSTNAME} partition_disk
 fi
 
 # Assign DISTRIBUTION to trigger things appropriately from automation-tools.
@@ -67,9 +67,9 @@ if [ "${SATELLITE_DISTRIBUTION}" = "INTERNAL" ]; then
     fi
 fi
 
-fab -H root@${SERVER_HOSTNAME} product_install:${DISTRIBUTION},sat_cdn_version=${SATELLITE_VERSION},test_in_stage=${STAGE_TEST}
+fab -D -H root@${SERVER_HOSTNAME} product_install:${DISTRIBUTION},sat_cdn_version=${SATELLITE_VERSION},test_in_stage=${STAGE_TEST}
 
 if [ ${SETUP_FAKE_MANIFEST_CERTIFICATE} = "true" ]; then
     source config/fake_manifest.conf
-    fab -H root@${SERVER_HOSTNAME} setup_fake_manifest_certificate
+    fab -D -H root@${SERVER_HOSTNAME} setup_fake_manifest_certificate
 fi

--- a/scripts/installer5.sh
+++ b/scripts/installer5.sh
@@ -5,15 +5,15 @@ source config/subscription_config.conf
 source config/sat5_activation_cert.conf
 
 if [ ${FIX_HOSTNAME} = "true" ]; then
-    fab -H root@${SERVER_HOSTNAME} fix_hostname
+    fab -D -H root@${SERVER_HOSTNAME} fix_hostname
 fi
 
 if [ ${PARTITION_DISK} = "true" ]; then
-    fab -H root@${SERVER_HOSTNAME} partition_disk
+    fab -D -H root@${SERVER_HOSTNAME} partition_disk
 fi
 
 # Figure out what version of RHEL the server uses
-OS_VERSION=$(fab -H root@${SERVER_HOSTNAME} distro_info | grep "rhel [[:digit:]]" | cut -d ' ' -f 2)
+OS_VERSION=$(fab -D -H root@${SERVER_HOSTNAME} distro_info | grep "rhel [[:digit:]]" | cut -d ' ' -f 2)
 # export chosen Jenkins job parameters for usage by fabric
 export RHN_PROFILE="robottelo_${SERVER_HOSTNAME}"
 
@@ -25,4 +25,4 @@ if [ ${DISTRIBUTION} = "CANDIDATE" ]; then
     export ISO_URL="http://download/devel/candidates/latest-link-Satellite-5.7.0-RHEL${OS_VERSION}-x86_64/iso/"
 fi
 
-fab -H root@${SERVER_HOSTNAME} satellite5_product_install
+fab -D -H root@${SERVER_HOSTNAME} satellite5_product_install

--- a/scripts/satellite6-libvirt-install.sh
+++ b/scripts/satellite6-libvirt-install.sh
@@ -22,7 +22,7 @@ function remove_instance () {
     export TARGET_IMAGE
     export SERVER_HOSTNAME="${TARGET_IMAGE}.${VM_DOMAIN}"
     set +e
-    fab -H "root@$1" "vm_destroy:target_image=${TARGET_IMAGE},delete_image=true"
+    fab -D -H "root@$1" "vm_destroy:target_image=${TARGET_IMAGE},delete_image=true"
     set -e
 }
 
@@ -41,7 +41,7 @@ elif [ "${SATELLITE_DISTRIBUTION}" = 'INTERNAL AK' ]; then
     export DISTRIBUTION="satellite6-activationkey"
 fi
 
-fab -H "root@${PROVISIONING_HOST}" "product_install:${DISTRIBUTION},create_vm=true,sat_cdn_version=${SATELLITE_VERSION},test_in_stage=${STAGE_TEST}"
+fab -D -H "root@${PROVISIONING_HOST}" "product_install:${DISTRIBUTION},create_vm=true,sat_cdn_version=${SATELLITE_VERSION},test_in_stage=${STAGE_TEST}"
 
 echo
 echo "========================================"

--- a/scripts/satellite6-provisioning.sh
+++ b/scripts/satellite6-provisioning.sh
@@ -24,8 +24,8 @@ export TARGET_IMAGE
 # set SERVER_HOSTNAME for the snapshot based pipelines by removing "-base" suffix if there is one
 export SERVER_HOSTNAME="${TARGET_IMAGE%%-base}.${VM_DOMAIN}"
 set +e
-fab -H "root@${PROVISIONING_HOST}" "vm_destroy:target_image=${TARGET_IMAGE},delete_image=true"
-for endpoint in tier1 tier2 tier3 tier4 rhai destructive coverage; do fab -H "root@${PROVISIONING_HOST}" "vm_destroy:target_image=${TARGET_IMAGE%%-base}-$endpoint,delete_image=true"; done
+fab -D -H "root@${PROVISIONING_HOST}" "vm_destroy:target_image=${TARGET_IMAGE},delete_image=true"
+for endpoint in tier1 tier2 tier3 tier4 rhai destructive coverage; do fab -D -H "root@${PROVISIONING_HOST}" "vm_destroy:target_image=${TARGET_IMAGE%%-base}-$endpoint,delete_image=true"; done
 set -e
 
 # Assign DISTRIBUTION to trigger things appropriately from automation-tools.
@@ -69,7 +69,7 @@ echo "DISCOVERY_ISO=${DISCOVERY_ISO}" >> build_env.properties
 # Run installation after writing the build_env.properties to make sure the
 # values are available for the post build actions, specially the foreman-debug
 # capturing.
-fab -H "root@${PROVISIONING_HOST}" "product_install:${DISTRIBUTION},create_vm=true,sat_cdn_version=${SATELLITE_VERSION},test_in_stage=${STAGE_TEST}"
+fab -D -H "root@${PROVISIONING_HOST}" "product_install:${DISTRIBUTION},create_vm=true,sat_cdn_version=${SATELLITE_VERSION},test_in_stage=${STAGE_TEST}"
 
 echo
 echo "========================================"


### PR DESCRIPTION
... to avoid errors like this:
```
++ fab -H root@server.example.com distro_info
++ grep 'rhel [[:digit:]]'
++ cut -d ' ' -f 2

Fatal error: Host key for server.example.com did not match pre-existing key! Server's key was changed recently, or possible man-in-the-middle attack.

Underlying exception:
    ('server.example.com', <paramiko.ecdsakey.ECDSAKey object at 0x7f311c335dd0>, <paramiko.ecdsakey.ECDSAKey object at 0x7f311c34f490>)

Aborting.
```