### PR TITLE
Update the JMS Messaging provider name after the plugin upgrade.

### DIFF
--- a/jobs/builders/satellite6_testcase_ci_subscribe.yaml
+++ b/jobs/builders/satellite6_testcase_ci_subscribe.yaml
@@ -4,7 +4,7 @@
         - raw:
             xml: |
                 <com.redhat.jenkins.plugins.ci.CIMessageSubscriberBuilder>
-                  <providerName>default</providerName>
+                  <providerName>CI Subscribe</providerName>
                   <selector>{selector}</selector>
                   <variable>TESTCASE_IMPORT_RESULTS</variable>
                   <timeout>180</timeout>


### PR DESCRIPTION
Can be merged if the polarion-test-case job PASSES, currently this fix is applied manually for testing the job.