### PR TITLE
Run sequential tests before parallel tests.

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -80,16 +80,18 @@ else
     TEST_TYPE="$(echo tests/foreman/{api,cli,ui,longrun})"
 fi
 
-if [ "${ENDPOINT}" != "rhai" ]; then
+if [ "${ENDPOINT}" == "destructive" ]; then
+    make test-foreman-sys
+elif [ "${ENDPOINT}" != "rhai" ]; then
     set +e
-    # Run parallel tests
-    $(which py.test) -v --junit-xml="${ENDPOINT}-parallel-results.xml" -n "${ROBOTTELO_WORKERS}" \
-        -m "${ENDPOINT} and not run_in_one_thread and not stubbed" \
-        ${TEST_TYPE}
-
     # Run sequential tests
     $(which py.test) -v --junit-xml="${ENDPOINT}-sequential-results.xml" \
         -m "${ENDPOINT} and run_in_one_thread and not stubbed" \
+        ${TEST_TYPE}
+
+    # Run parallel tests
+    $(which py.test) -v --junit-xml="${ENDPOINT}-parallel-results.xml" -n "${ROBOTTELO_WORKERS}" \
+        -m "${ENDPOINT} and not run_in_one_thread and not stubbed" \
         ${TEST_TYPE}
     set -e
 else


### PR DESCRIPTION
a) To speed up automation, we will be running sequential tests before
running parallel tests.

b) As parallel tests create multiple orgs and sequential tests have
   more number of tests which perform manifest upload.

c) So, the idea is if sequential tests are run before parallel tests
we would be speeding up the automation.

d) Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1339696

e) Also run destructive tests only in sequential, without -n option.