### PR TITLE
don't wrap foreman unittests with Xvfb

### DIFF
--- a/jobs/unittest/satellite6-unit-test-foreman.yaml
+++ b/jobs/unittest/satellite6-unit-test-foreman.yaml
@@ -14,8 +14,6 @@
       - merge_request
     scm:
       - foreman_gitlab
-    wrappers:
-      - default_xvfb
     triggers:
       - gitlab_build_on_change
     builders:


### PR DESCRIPTION
we don't have Xvfb set up, and this results in jobs failing with:

    ERROR: No Xvfb installations defined, please define one in the configuration. Once defined you’ll need to choose one under Advanced options for Xvfb plugin job settings and save job configuration.