### PR TITLE
execute tools.rb inside the bundle during cherry-pick

### DIFF
--- a/workflows/identifyCherryPicksWorkflow.groovy
+++ b/workflows/identifyCherryPicksWorkflow.groovy
@@ -6,7 +6,7 @@ node('rhel') {
     stage("Setup ToolBelt") {
         git url: "https://${env.GIT_HOSTNAME}/Satellite6/tool_belt.git", branch: 'master'
         sh 'bundle install --without=development'
-        sh "./tools.rb setup-environment --bugzilla --gitlab-username jenkins --version ${version}"
+        sh "bundle exec ruby ./tools.rb setup-environment --bugzilla --gitlab-username jenkins --version ${version}"
     }
 
     stage("Identify Cherry Picks") {
@@ -15,7 +15,7 @@ node('rhel') {
             [$class: 'UsernamePasswordMultiBinding', credentialsId: 'bugzilla-credentials', passwordVariable: 'BZ_PASSWORD', usernameVariable: 'BZ_USERNAME'],
             [$class: 'UsernamePasswordMultiBinding', credentialsId: 'octokit_token', passwordVariable: 'OCTOKIT_ACCESS_TOKEN', usernameVariable: 'OCTOKIT_TOKEN']]) {
 
-                sh "./tools.rb bugzilla cherry-pick --username ${env.BZ_USERNAME} --password ${env.BZ_PASSWORD} --version ${version} --milestone ${milestone} --no-update-repos"
+                sh "bundle exec ruby ./tools.rb bugzilla cherry-pick --username ${env.BZ_USERNAME} --password ${env.BZ_PASSWORD} --version ${version} --milestone ${milestone} --no-update-repos"
                 archive "releases/${version}/bugzillas"
           }
     }


### PR DESCRIPTION
otherwise you might end up with errors like:

    + ./tools.rb setup-environment --bugzilla --gitlab-username jenkins --version 6.2.0
    /usr/share/rubygems/rubygems/specification.rb:2030:in `raise_if_conflicts': Unable to activate httparty-0.13.7, because json-2.1.0 conflicts with json (~> 1.8) (Gem::LoadError)