### PR TITLE
use gitlabSourceNamespace if available

### DIFF
--- a/scripts/merge_request.sh
+++ b/scripts/merge_request.sh
@@ -5,7 +5,7 @@ if [ -n "${gitlabSourceBranch}" ]; then
     pushd plugin
   fi
 
-  git remote add pr https://$GIT_HOSTNAME/${gitlabSourceRepoName}.git
+  git remote add pr https://$GIT_HOSTNAME/${gitlabSourceNamespace:-}/${gitlabSourceRepoName}.git
   git fetch pr
   git merge pr/${gitlabSourceBranch}
 

--- a/workflows/lib/gitlab.groovy
+++ b/workflows/lib/gitlab.groovy
@@ -6,7 +6,7 @@ def gitlab_clone_and_merge(repo_name) {
             doGenerateSubmoduleConfigurations: false,
             extensions: [[$class: 'PreBuildMerge', options: [fastForwardMode: 'FF', mergeRemote: 'origin', mergeStrategy: 'default', mergeTarget: "${env.gitlabTargetBranch}"]]],
             submoduleCfg: [],
-            userRemoteConfigs: [[name: 'origin', url: "https://$GIT_HOSTNAME/$GIT_ORGANIZATION/${repo_name}.git"], [name: 'pr', url: "https://$GIT_HOSTNAME/${env.gitlabSourceRepoName}.git"]]
+            userRemoteConfigs: [[name: 'origin', url: "https://$GIT_HOSTNAME/$GIT_ORGANIZATION/${repo_name}.git"], [name: 'pr', url: "https://$GIT_HOSTNAME/${env.gitlabSourceNamespace}/${env.gitlabSourceRepoName}.git"]]
           ]
     } else {
         git url: "https://$GIT_HOSTNAME/$GIT_ORGANIZATION/${repo_name}.git", branch: gitlabTargetBranch

--- a/workflows/lib/gitlabEnv.groovy
+++ b/workflows/lib/gitlabEnv.groovy
@@ -1,5 +1,6 @@
 if (!env.getProperty('gitlabTargetBranch') && env.getProperty('targetBranch')) {
     env.setProperty('gitlabSourceBranch', env.getProperty('sourceBranch'))
     env.setProperty('gitlabSourceRepoName', env.getProperty('sourceRepoName'))
+    env.setProperty('gitlabSourceNamespace', '')
     env.setProperty('gitlabTargetBranch', env.getProperty('targetBranch'))
 }


### PR DESCRIPTION
our old jobs defined the name of the source repo *including* the
namespace, but GitLab itself does not do so in its hooks.

let's use gitlabSourceNamespace if it's defined, and otherwise define it
as an empty string to allow the old definitions to work