### PR TITLE
the cobertura option is called line, not lines

### DIFF
--- a/jobs/unittest/satellite6-unit-test-ohsnap.yaml
+++ b/jobs/unittest/satellite6-unit-test-ohsnap.yaml
@@ -23,7 +23,7 @@
       - cobertura:
           report-file: 'coverage/coverage.xml'
           targets:
-            - lines:
+            - line:
                 healthy: 80
                 unhealthy: 0
                 failing: 0


### PR DESCRIPTION
see https://docs.openstack.org/infra/jenkins-job-builder/publishers.html#publishers.cobertura