### PR TITLE
don't verify SSL certs when doing an upload

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -3,3 +3,4 @@ callback_plugins = playbooks/callback_plugins/
 callback_whitelist = profile_tasks
 inventory = inventory
 library = foreman-ansible-modules/modules
+module_utils = foreman-ansible-modules/module_utils

--- a/ansible/playbooks/upload_package.yml
+++ b/ansible/playbooks/upload_package.yml
@@ -10,3 +10,4 @@
         repository: "{{ repo }}"
         product: "{{ product }}"
         organization: "{{ organization }}"
+        verify_ssl: False


### PR DESCRIPTION
the default has changed recently in foreman-ansible-modules, but we
currently can't verify the cert

also set module_utils path, as otherwise ansible won't find the helpers