### PR TITLE
Install a smaller bundle for puppet tests

### DIFF
--- a/scripts/test_puppet_plugins.sh
+++ b/scripts/test_puppet_plugins.sh
@@ -7,6 +7,6 @@ rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 gem install bundler --no-ri --no-rdoc
 
-PUPPET_VERSION=${puppet} bundle install
+PUPPET_VERSION=${puppet} bundle install --without system_tests development
 
 ONLY_OS=redhat-6-x86_64,redhat-7-x86_64 bundle exec rake


### PR DESCRIPTION
This matches the upstream Travis configs where no acceptance tests are
run. That means fewer gems to install and fewer gems to pin on older
Ruby versions.