### PR TITLE
Allow Empty junit reports to not to fail the job

### DIFF
--- a/jobs/publishers/satellite6_automation_publishers.yaml
+++ b/jobs/publishers/satellite6_automation_publishers.yaml
@@ -4,4 +4,5 @@
         - junit:
             results: '*-results.xml'
             claim-build: true
+            allow-empty-results: true
         - claim-build


### PR DESCRIPTION
Standalone Satellite Upgrade Job is failing if existence tests do not run as it doesn't find reports file.

So allowing the job to Pass, if no reports file found