### PR TITLE
Support of skip Existence and Scenario Tests with BZ in Jenkins

### DIFF
--- a/scripts/satellite6-upgrade-source.sh
+++ b/scripts/satellite6-upgrade-source.sh
@@ -26,3 +26,9 @@ if [ "${{TO_VERSION}}" = '6.1' ]; then
     echo "ALERT!! The upgrade from 6.0 to 6.1 is not supported! Please perform it manually"
     exit 1
 fi
+
+# Export BZ credentials to skip the tests with BZ
+# This will be used robozilla's pytest_skip_if_bug_open decorator
+export BUGZILLA_ENVIRON_USER_NAME="${{BUGZILLA_USER}}"
+export BUGZILLA_ENVIRON_USER_PASSWORD_NAME="${{BUGZILLA_PASSWORD}}"
+export BUGZILLA_ENVIRON_SAT_VERSION="${{TO_VERSION}}"

--- a/scripts/satellite6_upgrader.sh
+++ b/scripts/satellite6_upgrader.sh
@@ -54,6 +54,11 @@ fi
 # Run upgrade for CDN/Downstream
 fab -u root product_upgrade:"${UPGRADE_PRODUCT}"
 
+# Export BZ credentials to skip the tests with BZ
+# This will be used robozilla's pytest_skip_if_bug_open decorator
+export BUGZILLA_ENVIRON_USER_NAME="${BUGZILLA_USER}"
+export BUGZILLA_ENVIRON_USER_PASSWORD_NAME="${BUGZILLA_PASSWORD}"
+export BUGZILLA_ENVIRON_SAT_VERSION="${TO_VERSION}"
 
 # Run existance tests
 if [ "${RUN_EXISTANCE_TESTS}" == 'true' ]; then


### PR DESCRIPTION
Providing Environment variables to satellite upgrade test which are:

- Skipped using robozilla's pytest_skip_if_bug_open decorator
       - where the decorator require these environment variables to function properly