### PR TITLE
use `popd` instead of `popd <dir>`

### DIFF
--- a/scripts/add_bastion_gitlab.sh
+++ b/scripts/add_bastion_gitlab.sh
@@ -3,5 +3,5 @@
 if [[ $gitlabTargetBranch == 'SATELLITE-6.2.0' ]];then
   pushd foreman
   echo "gem 'bastion', :git => 'https://${GIT_HOSTNAME}/${GIT_ORGANIZATION}/bastion.git', :branch => '${gitlabTargetBranch}'" >> bundler.d/Gemfile.local.rb
-  popd foreman
+  popd
 fi

--- a/scripts/add_foreman_docker_gitlab.sh
+++ b/scripts/add_foreman_docker_gitlab.sh
@@ -3,5 +3,5 @@
 if [[ $gitlabTargetBranch == 'SATELLITE-6.2.0' ]];then
   pushd foreman
   echo "gem 'foreman_docker', :git => 'https://${GIT_HOSTNAME}/${GIT_ORGANIZATION}/foreman_docker.git', :branch => '${gitlabTargetBranch}'" >> bundler.d/Gemfile.local.rb
-  popd foreman
+  popd
 fi

--- a/scripts/clone_foreman.sh
+++ b/scripts/clone_foreman.sh
@@ -14,4 +14,4 @@ if [ ${gitlabTargetBranch} == 'SATELLITE-6.3.0' ]; then
   sed -i "s/https:\/\/rubygems.org/${GEMSNAP_URL}/g" Gemfile
 fi
 
-popd foreman
+popd


### PR DESCRIPTION
`popd <dir>` is not a thing [1] and produces errors on modern bash
(tested on 4.3 and 4.4):

    popd fff
    bash: popd: fff: invalid argument
    popd: usage: popd [-n] [+N | -N]

and even on older (4.2) bash, this would not produce what we expect:

    # rpm -q bash
    bash-4.2.46-29.el7_4.x86_64
    # pwd
    /tmp
    # mkdir foo && pushd foo
    /tmp/foo /tmp
    # pwd
    /tmp/foo
    # popd foo
    /tmp/foo
    # pwd
    /tmp/foo

[1] https://www.gnu.org/software/bash/manual/html_node/Directory-Stack-Builtins.html