### PR TITLE
force 127.0.0.1 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ install:
   - pip install -r requirements.txt
 script:
   - ./setup_jjb.sh
+  - echo -e '[jenkins]\nurl=http://127.0.0.1:8080/' >> jenkins_jobs.ini
   - ./generate_jobs.sh


### PR DESCRIPTION
this workarounds the issue we have with Travis raising "[Errno 99] Cannot assign requested address" when trying to use IPv6 sockets