### PR TITLE
updated foreman-debug option (m/s) for max file sizes

### DIFF
--- a/scripts/satellite6-foreman-debug.sh
+++ b/scripts/satellite6-foreman-debug.sh
@@ -6,6 +6,6 @@ fi
 # Disable error checking, for more information check the related issue
 # http://projects.theforeman.org/issues/13442
 set +e
-ssh -o StrictHostKeyChecking=no "root@${SERVER_HOSTNAME}" foreman-debug -m 0 -q -d "~/foreman-debug"
+ssh -o StrictHostKeyChecking=no "root@${SERVER_HOSTNAME}" foreman-debug -s 0 -q -d "~/foreman-debug"
 set -e
 scp -o StrictHostKeyChecking=no -r "root@${SERVER_HOSTNAME}:~/foreman-debug.tar.xz" .


### PR DESCRIPTION
apparently, the file-size-limit parameter has been changed, causing the current setup to omit rotated log files.
```
+ set +e
+ ssh -o StrictHostKeyChecking=no root@sat6.com foreman-debug -m 0 -q -d '~/foreman-debug'
Warning: -m option has no effect, use -s option
```