### PR TITLE
pass foreman-debug options based on sat version

### DIFF
--- a/scripts/satellite6-foreman-debug.sh
+++ b/scripts/satellite6-foreman-debug.sh
@@ -3,9 +3,17 @@ rm -rf foreman-debug.tar.xz
 if [ ! "${SERVER_HOSTNAME}" ]; then
     SERVER_HOSTNAME="$(grep SERVER_HOSTNAME build_env.properties | cut -d= -f2-)"
 fi
+if [ ! "${SATELLITE_VERSION}" ]; then
+    SATELLITE_VERSION="$(grep SATELLITE_VERSION build_env.properties | cut -d= -f2-)"
+fi
 # Disable error checking, for more information check the related issue
 # http://projects.theforeman.org/issues/13442
 set +e
-ssh -o StrictHostKeyChecking=no "root@${SERVER_HOSTNAME}" foreman-debug -s 0 -q -d "~/foreman-debug"
+# option have changed from m to s  in sat6.3
+if [[ ${SATELLITE_VERSION} =~ 6\.[0-2]$ ]]; then
+    ssh -o StrictHostKeyChecking=no "root@${SERVER_HOSTNAME}" foreman-debug -m 0 -q -d "~/foreman-debug"
+else
+    ssh -o StrictHostKeyChecking=no "root@${SERVER_HOSTNAME}" foreman-debug -s 0 -q -d "~/foreman-debug"
+fi
 set -e
 scp -o StrictHostKeyChecking=no -r "root@${SERVER_HOSTNAME}:~/foreman-debug.tar.xz" .


### PR DESCRIPTION
i realized that `6.2` and earlier versions did not updated the `foreman-debug` options, thus, the new '-s' option wouldn't be recognized there.

this commit adds a conditional based on the `$SATELLITE_VERSION` env variable.

```bash
$ for i in 6.{0..5} 'downstream-nightly']; do if [[ $i =~ 6\.[0-2]$ ]]; then  echo "-m"; else echo "-s"; fi done
-m
-m
-m
-s
-s
-s
-s

```