### PR TITLE
don't check SSL in the ansible playbooks

### DIFF
--- a/ansible/playbooks/promote_content_view.yaml
+++ b/ansible/playbooks/promote_content_view.yaml
@@ -11,3 +11,4 @@
         to_environment: "{{ to_lifecycle_environment }}"
         from_environment: "{{ from_lifecycle_environment }}"
         force: true
+        verify_ssl: False

--- a/ansible/playbooks/publish_content_views.yml
+++ b/ansible/playbooks/publish_content_views.yml
@@ -10,3 +10,4 @@
         server_url: "{{ server }}"
         content_view: "{{ content_view }}"
         organization: "{{ organization }}"
+        verify_ssl: False

--- a/ansible/playbooks/sync_repositories.yml
+++ b/ansible/playbooks/sync_repositories.yml
@@ -10,3 +10,4 @@
         server_url: "{{ server }}"
         product: "{{ product }}"
         organization: "{{ organization }}"
+        verify_ssl: False

--- a/ansible/playbooks/upload_package.yml
+++ b/ansible/playbooks/upload_package.yml
@@ -10,3 +10,4 @@
         repository: "{{ repo }}"
         product: "{{ product }}"
         organization: "{{ organization }}"
+        verify_ssl: False


### PR DESCRIPTION
we sadly have a jenkins slave that is not capable of checking the certs
correctly. we could either not use that slave, or not check ssl.

This reverts commit c70315eb836f51c358d34d3c990776a24354df62.