### PR TITLE
Added support for running chrome on saucelabs and updated FF version for standalone job

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -23,6 +23,8 @@ if [[ "${SAUCE_PLATFORM}" != "no_saucelabs" ]]; then
         fi
     elif [[ "${SAUCE_BROWSER}" == "edge" ]]; then
         BROWSER_VERSION=14.14393
+    elif [[ "${SAUCE_BROWSER}" == "chrome" ]]; then
+        BROWSER_VERSION=63.0
     fi
     # Temporary change to test Selenium and Firefox changes.
     if [[ "${SATELLITE_VERSION}" == "6.1" ]]; then

--- a/scripts/satellite6-standalone-automation.sh
+++ b/scripts/satellite6-standalone-automation.sh
@@ -32,9 +32,15 @@ if [[ "${SAUCE_PLATFORM}" != "no_saucelabs" ]]; then
     sed -i "s/^# saucelabs_key=.*/saucelabs_key=${SAUCELABS_KEY}/" robottelo.properties
     sed -i "s/^# webdriver=.*/webdriver=${SAUCE_BROWSER}/" robottelo.properties
     if [[ "${SAUCE_BROWSER}" == "firefox" ]]; then
-        BROWSER_VERSION=45.0
+        if [[ "${SATELLITE_VERSION}" == "6.1" ]]; then
+            BROWSER_VERSION=45.0
+        else
+            BROWSER_VERSION=47.0
+        fi
     elif [[ "${SAUCE_BROWSER}" == "edge" ]]; then
         BROWSER_VERSION=14.14393
+    elif [[ "${SAUCE_BROWSER}" == "chrome" ]]; then
+        BROWSER_VERSION=63.0
     fi
     sed -i "s/^# webdriver_desired_capabilities=.*/webdriver_desired_capabilities=platform=${SAUCE_PLATFORM},version=${BROWSER_VERSION},idleTimeout=1000,seleniumVersion=2.48.0,build=${SATELLITE_VERSION}-$(date +%Y-%m-%d-%S),screenResolution=1600x1200,tunnelIdentifier=${TUNNEL_IDENTIFIER}/" robottelo.properties
 fi


### PR DESCRIPTION
`BROWSER_VERSION` var wasn't set in case `chrome` is selected making script fail.
FF version for automation is 47, so i think standalone job should use the same version to avoid differences in test results.