### PR TITLE
use an oldschool for-loop when looking for packages

### DIFF
--- a/workflows/satellite-packaging/buildSatellitePackaging.groovy
+++ b/workflows/satellite-packaging/buildSatellitePackaging.groovy
@@ -68,11 +68,14 @@ node('sat6-rhel7') {
 }
 
 def mark_bugs_built(packages_to_build) {
+    def packages = packages_to_build.split(':')
+
     dir('tool_belt') {
         setup_toolbelt()
     }
 
-    for (String package_name: packages_to_build.split(':')) {
+    for (int i = 0; i < packages.size(); i++) {
+        package_name = packages[i]
         rpm = sh(returnStdout: true, script: "rpmspec -q --srpm --queryformat=%{NVR} packages/${package_name}/*.spec").trim()
         ids = sh(returnStdout: true, script: "rpmspec -q --srpm --queryformat=%{CHANGELOGTEXT} packages/${package_name}/*.spec |grep '^- BZ' | sed -E 's/^- BZ[ #]+?([0-9]+).*/\\1/'").trim().split("\n")
 


### PR DESCRIPTION
for some reason Jenkins can't do `sh` inside a for-loop that uses
abstract lists