### PR TITLE
Add params SUBNET, NETMASK also to installer job to allow internal capsule subnet customization

### DIFF
--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -107,15 +107,26 @@
         - string:
             name: GATEWAY
             description: |
-                Default value is '192.168.100.1', which is automatically set by installer.
+                Default value is '192.168.100.1', which is automatically set by installer job.
                 Used for, --foreman-proxy-dhcp-gateway and --foreman-proxy-dns-reverse installer options.
                 If using isolated vlans explicitly specify the gateway here, which would be in the format
                 'zz.xx.yy.254'. Mandatory if installing sat6 which has isolated VLANs, Otherwise this is Optional.
-
+        - string:
+            name: SUBNET
+            description: |
+                Default value is '192.168.100.0', which is automatically set by installer job.
+                Used to define subnet that is operated by Satellite's internal capsule.
+                Mandatory if installing sat6 which has isolated VLANs, Otherwise this is Optional.
+        - string:
+            name: NETMASK
+            description: |
+                Default value is '255.255.255.0', which is automatically set by installer job.
+                Used to define subnet that is operated by Satellite's internal capsule.
+                Mandatory if installing sat6 which has isolated VLANs, Otherwise this is Optional.
         - string:
             name: DHCP_RANGE
             description: |
-                This is required when we need to set a custom DHCP range.
+                This is required when we need to set a custom DHCP range operated by internal capsule.
                 Completely Optional but would be helpful to have.
         - string:
             name: INSTALLER_OPTIONS


### PR DESCRIPTION
to fix satellite6-installer for custom setups:
```
[server] run: hammer -u admin -p changeme subnet create --name "Default Subnet" --network 192.168.100.0 --mask 255.255.255.0 --gateway 192.168.101.1 --dns-primary 192.168.101.1 --ipam DHCP --from 192.168.101.10 --to 192.168.101.250 --dhcp-id 1 --dns-id 1 --tftp-id 1 --discovery-id 1
[server] out: Could not create the subnet:
[server] out:   Start of IP range does not belong to subnet
[server] out:   End of IP range does not belong to subnet
[server] out: 

Fatal error: run() received nonzero return code 65 while executing!
```
- able to set gateway 
  vs.
- not able to set netaddr & netmask