### PR TITLE
migrate satellite-packaging workflows to obal

### DIFF
--- a/jobs/sat-63-satellite-packaging-release-build.yaml
+++ b/jobs/sat-63-satellite-packaging-release-build.yaml
@@ -16,7 +16,7 @@
         - workflows/lib/gitlabEnv.groovy
         - workflows/satellite-packaging/releaseBuildSatellitePackaging.groovy
         - workflows/satellite-packaging/buildSatellitePackaging.groovy
-        - workflows/lib/runPlaybook.groovy
+        - workflows/lib/obal.groovy
         - workflows/lib/toolbelt.groovy
         - workflows/lib/kerberos.groovy
         - workflows/lib/gitlab.groovy

--- a/jobs/sat-63-satellite-packaging-scratch-build.yaml
+++ b/jobs/sat-63-satellite-packaging-scratch-build.yaml
@@ -16,7 +16,7 @@
         - workflows/lib/gitlabEnv.groovy
         - workflows/satellite-packaging/scratchBuildSatellitePackaging.groovy
         - workflows/satellite-packaging/buildSatellitePackaging.groovy
-        - workflows/lib/runPlaybook.groovy
+        - workflows/lib/obal.groovy
         - workflows/lib/toolbelt.groovy
         - workflows/lib/kerberos.groovy
         - workflows/lib/gitlab.groovy

--- a/workflows/lib/obal.groovy
+++ b/workflows/lib/obal.groovy
@@ -1,0 +1,17 @@
+def obal(body) {
+
+    def config = [:]
+    body.resolveStrategy = Closure.DELEGATE_FIRST
+    body.delegate = config
+    body()
+
+    def tags = config.tags ? "--tags ${config.tags}" : ""
+
+    dir('obal') {
+        git url: "https://github.com/evgeni/obal.git", branch: "master"
+    }
+
+    wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "xterm"]) {
+        sh "ANSIBLE_FORCE_COLOR=true PYTHONPATH=obal/ python -m obal.__init__ ${tags} ${config.action} ${config.packages}"
+    }
+}

--- a/workflows/satellite-packaging/buildSatellitePackaging.groovy
+++ b/workflows/satellite-packaging/buildSatellitePackaging.groovy
@@ -17,11 +17,11 @@ node('sat6-rhel7') {
             // check if we got two parents, otherwise it's not a merge
             if (merge_info.length == 3) {
                 changed_packages = sh(returnStdout: true, script: "git diff ${merge_info[1]}...${merge_info[2]} --name-only 'packages/*.spec' | cut -d'/' -f2 |sort -u").trim()
-                packages_to_build = changed_packages.split().join(':')
+                packages_to_build = changed_packages.split().join(' ')
             }
         } else if (build_type == 'scratch') {
             changed_packages = sh(returnStdout: true, script: "git diff ..origin/${env.gitlabTargetBranch} --name-only 'packages/*.spec' | cut -d'/' -f2 |sort -u").trim()
-            packages_to_build = changed_packages.split().join(':')
+            packages_to_build = changed_packages.split().join(' ')
         }
         if (!packages_to_build) {
             currentBuild.result = 'NOT_BUILT'
@@ -37,12 +37,10 @@ node('sat6-rhel7') {
             kerberos_setup()
 
             gitlabCommitStatus(build_type) {
-                runPlaybook {
-                    ansibledir = '.'
-                    inventory = 'package_manifest.yaml'
-                    playbook = packaging_playbook
-                    limit = packages_to_build
-                    tags = 'wait,download'
+                obal {
+                    action = build_type
+                    tags = "wait,download"
+                    packages = packages_to_build
                 }
             }
 

--- a/workflows/satellite-packaging/releaseBuildSatellitePackaging.groovy
+++ b/workflows/satellite-packaging/releaseBuildSatellitePackaging.groovy
@@ -1,2 +1,1 @@
 def build_type = 'release'
-def packaging_playbook = 'release_package.yml'

--- a/workflows/satellite-packaging/scratchBuildSatellitePackaging.groovy
+++ b/workflows/satellite-packaging/scratchBuildSatellitePackaging.groovy
@@ -1,2 +1,1 @@
 def build_type = 'scratch'
-def packaging_playbook = 'scratch_build.yml'


### PR DESCRIPTION
this is a first attempt to move our packaging pipelines to the new `obal` wrapper.

the invocation (`PYTHONPATH=obal/ python -m obal.__init__`) is a tad ugly as long we're running directly from a git checkout, and not from an installed module.