### PR TITLE
Revert "Strings passed to Obal get double quoted and breaks RPMs"

### DIFF
--- a/workflows/lib/obal.groovy
+++ b/workflows/lib/obal.groovy
@@ -9,7 +9,7 @@ def obal(body) {
     def extra_vars = config.extraVars ?: [:]
     def extra_vars_args = []
     extra_vars.each { key, val ->
-       extra_vars_args += $/-e '${key}=${val}'/$
+       extra_vars_args += $/-e '${key}="${val}"'/$
     }
 
     dir('obal') {


### PR DESCRIPTION
This reverts commit 163e48917f6aa5ab3489aaa6ef7f8b7a12697968.