### PR TITLE
cancel the right pipeline step in GitLab

### DIFF
--- a/workflows/satellite-packaging/buildSatellitePackaging.groovy
+++ b/workflows/satellite-packaging/buildSatellitePackaging.groovy
@@ -25,7 +25,7 @@ node('sat6-rhel7') {
         }
         if (!packages_to_build) {
             currentBuild.result = 'NOT_BUILT'
-            updateGitlabCommitStatus state: 'canceled'
+            updateGitlabCommitStatus name: build_type, state: 'canceled'
             error('No packages to build.')
         }
         update_build_description_from_packages(packages_to_build)


### PR DESCRIPTION
we use custom names (build_type), but don't pass that when canceling the
pipeline, thus resulting in the build_type step still being displayed as
pending in the UI