### PR TITLE
Satellite6.3 now uses the 6.3.z branch of robottelo

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -1102,7 +1102,8 @@
             scm-branch: origin/6.1.z
         - '6.2':
             scm-branch: origin/6.2.z
-        - '6.3'
+        - '6.3':
+            scm-branch: origin/6.3.z
         - 'upstream-nightly'
         - 'downstream-nightly'
     os:
@@ -1135,7 +1136,8 @@
     satellite_version:
         - '6.2':
             scm-branch: origin/6.2.z
-        - '6.3'
+        - '6.3':
+            scm-branch: origin/6.3.z
     os:
         - 'rhel6'
         - 'rhel7'


### PR DESCRIPTION
Signed-off-by: Kedar Bidarkar <kbidarka@redhat.com>