### PR TITLE
Added support for foreman-maintain in CustomerDb

### DIFF
--- a/jobs/satellite6-db-upgrade-migrate.yaml
+++ b/jobs/satellite6-db-upgrade-migrate.yaml
@@ -76,6 +76,11 @@
             description: |
                 <p>Un-Check if you do not want to perform upgrade post Satellite Clone or Migration</p>
         - bool:
+            name: PERFORM_FOREMAN_MAINTAIN_UPGRADE
+            default: false
+            description: |
+                <p>Check if you want to perform upgrade using Foreman-Maintain Tool. This needs PERFORM_UPGRADE parameter unchecked.</p>
+        - bool:
             name: RUN_EXISTENCE_TESTS
             default: false
             description: |

--- a/scripts/satellite6_db_upgrade_migrate.sh
+++ b/scripts/satellite6_db_upgrade_migrate.sh
@@ -108,3 +108,11 @@ if [ "${PERFORM_UPGRADE}" = "true" ]; then
         tar -czf Log_Analyzer_Logs.tar.xz upgrade-diff-logs
     fi
 fi
+
+# Run satellite upgrade only when PERFORM_FOREMAN_MAINTAIN_UPGRADE flag is set
+if [ "${PERFORM_FOREMAN_MAINTAIN_UPGRADE}" = "true" ]; then
+    # setup foreman-maintain
+    fab -u root@"${SATELLITE_HOSTNAME}" setup_foreman_maintain
+    # perform upgrade using foreman-maintain
+    fab -u root@"${SATELLITE_HOSTNAME}" upgrade_using_foreman_maintain
+fi


### PR DESCRIPTION
Relies on https://github.com/SatelliteQE/satellite6-upgrade/pull/151 

Now perform the customer Db upgrade using foreman-maintain tool as well.
Added a parameter `PERFORM_FOREMAN_MAINTAIN_UPGRADE` if checked, will perform the upgrade using foreman-maintain.

