### PR TITLE
New job for mass registration of container hosts to Satellite

### DIFF
--- a/jobs/satellite6-mass-registration.yaml
+++ b/jobs/satellite6-mass-registration.yaml
@@ -1,0 +1,44 @@
+- job:
+    name: satellite6-mass-registration
+    node: sat6-rhel6
+    concurrent: true
+    description: |
+        <p>This can be used to trigger mass registration of content hosts to a Satellite</p>
+    parameters:
+        - string:
+            name: SATELLITE_HOST
+            description: FQDN of the Satellite server.
+        - string:
+            name: CONTAINER_HOST
+            description: FQDN of the Container host (only rhel7 supported).
+        - string:
+            name: CONTENT_HOST_PREFIX
+            description: No special characters allowed.
+        - string:
+            name: ACTIVATION_KEY
+            description: Activation key for a rhel7 content host.
+        - string:
+            name: EXIT_CRITERIA
+            default: registration
+            description: Exit Criteria to terminate the container. Enter `registration` or `katello-agent` or <time in seconds>.
+        - string:
+            name: NUMBER_OF_HOSTS
+            description: Number of content hosts to be created.
+        - bool:
+            name: SETUP_CONTAINER_HOST
+            default: false
+            description: If you already had setup the container host, make sure /content-host-d folder has the flood.py script.
+    scm:
+      - git:
+          url: 'https://github.com/JacobCallahan/content-host-d.git'
+          branches:
+              - origin/master
+          skip-tag: true
+          wipe-workspace: true
+    wrappers:
+        - config-file-provider:
+            files:
+                - file-id: bc5f0cbc-616f-46de-bdfe-2e024e84fcbf
+                  variable: CONFIG_FILES
+    builders:
+        - shell: 'scripts/satellite6-mass-registration.sh'

--- a/scripts/satellite6-mass-registration.sh
+++ b/scripts/satellite6-mass-registration.sh
@@ -1,0 +1,14 @@
+echo "Sourcing config files for cdn registration.."
+source ${CONFIG_FILES}
+source config/subscription_config.conf
+
+echo "Setting up Container Host"
+if [ "${SETUP_CONTAINER_HOST}" == "true" ]; then
+    cd playbooks
+    # Note that the following playbook is temporarily hardcoded to generate rhel74 image.
+    ansible-playbook --inventory=${CONTAINER_HOST}, --extra-vars "RHN_USERNAME=${RHN_USERNAME} RHN_PASSWORD=${RHN_PASSWORD} RHN_POOLID=${RHN_POOLID} WORKSPACE=${WORKSPACE}" chd-setup.yaml
+fi
+
+echo "Run the command for the container hosts registration"
+cd ${WORKSPACE}/playbooks
+ansible-playbook --inventory=${CONTAINER_HOST}, --extra-vars "SATELLITE_HOST=${SATELLITE_HOST} CONTENT_HOST_PREFIX=${CONTENT_HOST_PREFIX} ACTIVATION_KEY=${ACTIVATION_KEY} NUMBER_OF_HOSTS=${NUMBER_OF_HOSTS} EXIT_CRITERIA=${EXIT_CRITERIA}" chd-run.yaml


### PR DESCRIPTION
Background: We need a Jenkins job to quickly test mass content host registrations to Satellite.

This new job will do the following:
1. (Optionally) setup the container host by installing ansible and setup all the necessary repos for running the script
2. Run mass registration script accepting variable parameters from the user to customize the specific needs of a test scenario.

The idea behind this specific job for now is automate the manual steps in Jenkins. Specific improvement around the playbook used and the flood.py script are planned for the near future.