### PR TITLE
Added support for foreman-maintain in satellite6-upgrader

### DIFF
--- a/jobs/satellite6-upgrader.yaml
+++ b/jobs/satellite6-upgrader.yaml
@@ -76,6 +76,11 @@
             default: false
             description: |
                  <p>Run tests to verify certain upgarde specific scenarios.</p>
+        - bool:
+            name: PERFORM_FOREMAN_MAINTAIN_UPGRADE
+            default: false
+            description: |
+                <p>Check if you want to perform upgrade using Foreman-Maintain Tool.</p>
         - string:
             name: SATELLITE_HOSTNAME
             description: |


### PR DESCRIPTION
Now perform standalone satellite upgrade using foreman-maintain.
Added check `PERFORM_FOREMAN_MAINTAIN_UPGRADE` 