### PR TITLE
Switch to uppercase D for diff-filter

### DIFF
--- a/workflows/lib/packaging.groovy
+++ b/workflows/lib/packaging.groovy
@@ -175,7 +175,7 @@ def mark_bugs_built(build_status, packages_to_build, package_version, tool_belt_
 }
 
 def find_changed_packages(diff_range) {
-    return sh(returnStdout: true, script: "git diff ${diff_range} --name-only --diff-filter=d -- 'packages/**.spec' | cut -d'/' -f2 |sort -u").trim()
+    return sh(returnStdout: true, script: "git diff ${diff_range} --name-only --diff-filter=D -- 'packages/**.spec' | cut -d'/' -f2 |sort -u").trim()
 }
 
 def get_brew_comment(build_status) {


### PR DESCRIPTION
Testing this locally:

```
ehelms@war satellite-packaging (SATELLITE-6.4.0)$ git merge 8fe1414dd5192c50184ac0d799708a04cf24d432
Merge made by the 'recursive' strategy.
 packages/tfm-ror51-rubygem-arel/arel-8.0.0.gem              | Bin 0 -> 32256 bytes
 packages/tfm-ror51-rubygem-arel/tfm-ror51-rubygem-arel.spec |  82 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 82 insertions(+)
 create mode 100644 packages/tfm-ror51-rubygem-arel/arel-8.0.0.gem
 create mode 100644 packages/tfm-ror51-rubygem-arel/tfm-ror51-rubygem-arel.spec
ehelms@war satellite-packaging (SATELLITE-6.4.0)$ git diff ..origin/SATELLITE-6.4.0 --name-only --diff-filter=d -- 'packages/**.spec'
ehelms@war satellite-packaging (SATELLITE-6.4.0)$ git diff ..origin/SATELLITE-6.4.0 --name-only -- 'packages/**.spec'
packages/tfm-ror51-rubygem-arel/tfm-ror51-rubygem-arel.spec
ehelms@war satellite-packaging (SATELLITE-6.4.0)$ git diff ..origin/SATELLITE-6.4.0 --name-only --diff-filter=da -- 'packages/**.spec'
ehelms@war satellite-packaging (SATELLITE-6.4.0)$ git diff ..origin/SATELLITE-6.4.0 --name-only --diff-filter=D -- 'packages/**.spec'
packages/tfm-ror51-rubygem-arel/tfm-ror51-rubygem-arel.spec
ehelms@war satellite-packaging (SATELLITE-6.4.0)$ git diff ..origin/SATELLITE-6.4.0 --name-only --diff-filter=A -- 'packages/**.spec'
ehelms@war satellite-packaging (SATELLITE-6.4.0)$ git diff ..origin/SATELLITE-6.4.0 --name-only --diff-filter=a -- 'packages/**.spec'
packages/tfm-ror51-rubygem-arel/tfm-ror51-rubygem-arel.spec
```