### PR TITLE
keep packaging builds longer than the default

### DIFF
--- a/jobs/sat-63-satellite-packaging-release-build.yaml
+++ b/jobs/sat-63-satellite-packaging-release-build.yaml
@@ -5,6 +5,12 @@
     build-discarder:
       days-to-keep: 45
       num-to-keep: -1
+    properties:
+      - build-discarder:
+          days-to-keep: 45
+          num-to-keep: -1
+      - gitlab:
+          connection: gitlab-conn
     parameters:
       - string:
           name: project

--- a/jobs/sat-63-satellite-packaging-scratch-build.yaml
+++ b/jobs/sat-63-satellite-packaging-scratch-build.yaml
@@ -5,6 +5,12 @@
     build-discarder:
       days-to-keep: 45
       num-to-keep: -1
+    properties:
+      - build-discarder:
+          days-to-keep: 45
+          num-to-keep: -1
+      - gitlab:
+          connection: gitlab-conn
     parameters:
       - string:
           name: project


### PR DESCRIPTION
it seems we now have to set it via properties, not as a direct setting