### PR TITLE
Fixes the OSP support in DB migrate job 

### DIFF
--- a/jobs/satellite6-db-upgrade-migrate.yaml
+++ b/jobs/satellite6-db-upgrade-migrate.yaml
@@ -63,6 +63,11 @@
             description:
                 <p>Currently, only supports Verizon database. Instance will be created on OSP</p>
                 <p>Make sure to check resources available on Openstack before using the option</p>
+        - string:
+            name: VOLUME_SIZE
+            default: '500'
+            description: |
+                <p>The Size of the volume for creating OSP Instance. Defaults to 500 GB</p>
         - bool:
             name: INCLUDE_PULP_DATA
             default: false


### PR DESCRIPTION
Also, adds the volume size customization in job. Default volume for OSP is 500GB

Tested Job: /job/satellite6_db_upgrade_migrate/330/