### PR TITLE
Fix : POLARION RELEASE in Upgrade Tier Tests result upload

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -1100,7 +1100,7 @@
             - project: 'polarion-upgraded-test-run-{satellite_version}-{os}'
               predefined-parameters: |
                   TEST_RUN_ID=$BUILD_LABEL {os} upgrade
-                  POLARION_RELEASE=$POLARION_RELEASE
+                  POLARION_RELEASE=$POLARION_RELEASE upgrade
     publishers:
         - satellite6-automation-mails
         - satellite6-automation-publishers

--- a/scripts/satellite6-betelgeuse-test-run.sh
+++ b/scripts/satellite6-betelgeuse-test-run.sh
@@ -17,19 +17,12 @@ else
     exit 1
 fi
 
-# Change Test plan name for upgrade
-if [[ "${TEST_RUN_ID}" = *"upgrade"* ]]; then
-    TEST_PLAN_NAME = "${TEST_RUN_ID} upgrade"
-else
-    TEST_PLAN_NAME = "${TEST_RUN_ID}"
-fi
-
 # Create a new iteration for the current run
 if [ -n "$POLARION_RELEASE" ]; then
-    betelgeuse test-plan --name "${TEST_PLAN_NAME}" --parent-name "${POLARION_RELEASE}" \
+    betelgeuse test-plan --name "${TEST_RUN_ID}" --parent-name "${POLARION_RELEASE}" \
         --plan-type iteration "${POLARION_PROJECT}"
 else
-    betelgeuse test-plan --name "${TEST_PLAN_NAME}" \
+    betelgeuse test-plan --name "${TEST_RUN_ID}" \
         --plan-type iteration "${POLARION_PROJECT}"
 fi
 


### PR DESCRIPTION
This should fix the plan-name and test-run id for Upgrade job.