### PR TITLE
Correct and collect corrected xmls for polarion upgrade test results

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -492,11 +492,11 @@
     builders:
         - shell: rm -f *.xml
         - copyartifact:
-            project: 'automation-upgraded-{satellite_version}-tier1-{os}'
+            project: 'automation-upgraded-{satellite_version}-all-tiers-{os}'
             filter: '*-results.xml'
             which-build: last-successful
         - copyartifact:
-            project: 'automation-upgraded-{satellite_version}-tier2-{os}'
+            project: 'automation-upgraded-{satellite_version}-end-to-end-{os}'
             filter: '*-results.xml'
             which-build: last-successful
         - satellite6-automation-reports-builders
@@ -754,7 +754,7 @@
             name: ROBOTTELO_WORKERS
             default: '8'
             description: |
-                Number of workers to use while running robottelo tier1 test suite
+                Number of workers to use while running robottelo all tiers test suite
                 after the upgrade.
         - bool:
             name: ZSTREAM_UPGRADE
@@ -875,7 +875,7 @@
             name: ROBOTTELO_WORKERS
             default: '8'
             description: |
-                Number of workers to use while running robottelo tier1 test suite
+                Number of workers to use while running robottelo all tiers test suite
                 after the upgrade.
         - bool:
             name: ZSTREAM_UPGRADE
@@ -1009,7 +1009,7 @@
         - trigger-builds:
             - project: 'satellite6-manifest-downloader'
         - trigger-builds:
-            - project: 'automation-upgraded-{satellite_version}-tier1-{os}'
+            - project: 'automation-upgraded-{satellite_version}-all-tiers-{os}'
               current-parameters: true
     publishers:
         - satellite6-automation-mails
@@ -1019,7 +1019,7 @@
 
 - job-template:
     disabled: false
-    name: 'automation-upgraded-{satellite_version}-tier1-{os}'
+    name: 'automation-upgraded-{satellite_version}-all-tiers-{os}'
     node: sat6-rhel7
     build-discarder:
         num-to-keep: 16
@@ -1042,7 +1042,7 @@
         - inject:
             properties-content: |
                 SATELLITE_VERSION={satellite_version}
-                ENDPOINT=tier1,tier2,tier3
+                ENDPOINT=all-tiers
                 OS={os}
         - satellite6-maskpassword-wrappers
         - satellite6-sauce-ondemand-wrappers
@@ -1051,7 +1051,7 @@
         - trigger-builds:
             - project: 'satellite6-manifest-downloader'
         - trigger-builds:
-            - project: 'automation-upgraded-{satellite_version}-tier2-{os}'
+            - project: 'automation-upgraded-{satellite_version}-end-to-end-{os}'
               current-parameters: true
     publishers:
         - satellite6-automation-mails
@@ -1060,7 +1060,7 @@
 
 - job-template:
     disabled: false
-    name: 'automation-upgraded-{satellite_version}-tier2-{os}'
+    name: 'automation-upgraded-{satellite_version}-end-to-end-{os}'
     node: sat6-rhel7
     build-discarder:
         num-to-keep: 16
@@ -1356,8 +1356,8 @@
         - 'upgrade-phase-{satellite_version}-{os}'
         - 'automation-upgraded-{satellite_version}-existence-tests-{os}'
         - 'automation-postupgrade-{satellite_version}-scenario-tests-{os}'
-        - 'automation-upgraded-{satellite_version}-tier1-{os}'
-        - 'automation-upgraded-{satellite_version}-tier2-{os}'
+        - 'automation-upgraded-{satellite_version}-all-tiers-{os}'
+        - 'automation-upgraded-{satellite_version}-end-to-end-{os}'
         - 'polarion-upgraded-test-run-{satellite_version}-{os}'
         - 'report-upgrade-tier-automation-results-{satellite_version}-{os}'
 

--- a/scripts/satellite6-upgrade-tier-source.sh
+++ b/scripts/satellite6-upgrade-tier-source.sh
@@ -114,13 +114,13 @@ fi
 
 if [ "${ENDPOINT}" != "end-to-end" ]; then
     set +e
-    # Run all sequential tests with upgrade mark
-    $(which py.test) -v --junit-xml="upgrade-sequential-results.xml" \
+    # Run all tiers sequential tests with upgrade mark
+    $(which py.test) -v --junit-xml="${ENDPOINT}-upgrade-sequential-results.xml" \
         -m "upgrade and run_in_one_thread and not stubbed" \
         ${TEST_TYPE}
 
-    # Run all parallel tests with upgrade mark
-    $(which py.test) -v --junit-xml="upgrade-parallel-results.xml" -n "${ROBOTTELO_WORKERS}" \
+    # Run all tiers parallel tests with upgrade mark
+    $(which py.test) -v --junit-xml="${ENDPOINT}-upgrade-parallel-results.xml" -n "${ROBOTTELO_WORKERS}" \
         -m "upgrade and not run_in_one_thread and not stubbed" \
         ${TEST_TYPE}
     set -e


### PR DESCRIPTION
The polarion upgrade tier results upload job is failing due to:
```
Error: Invalid value for "junit-path": Path "./tier1-parallel-results.xml" does not exist.
```

The file is not found because the file was being created with name 'upgrade-parallel-results.xml'. 

Hence both create name and request name is changed to 'tier1-upgrade-parallel-results.xml' in both files.