### PR TITLE
switch the order of the options for the satellite versions for satellite6 installer job

### DIFF
--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -39,8 +39,8 @@
         - choice:
             name: SATELLITE_VERSION
             choices:
-                - '6.3'
                 - '6.4'
+                - '6.3'
                 - '6.2'
                 - '6.1'
                 - '6.0'


### PR DESCRIPTION
this is just an UX change