### PR TITLE
Added support for 6.3 customer dbs

### DIFF
--- a/jobs/parameters/satellite6_upgrade_parameters.yaml
+++ b/jobs/parameters/satellite6_upgrade_parameters.yaml
@@ -4,6 +4,7 @@
         - choice:
             name: FROM_VERSION
             choices:
+                - '6.3'
                 - '6.2'
                 - '6.1'
             description: |
@@ -11,8 +12,9 @@
         - choice:
             name: TO_VERSION
             choices:
-                - '6.2'
+                - '6.4'
                 - '6.3'
+                - '6.2'
             description: |
                 <p>Select the Satellite version to upgrade</p>
         - choice:

--- a/jobs/satellite6-db-upgrade-migrate.yaml
+++ b/jobs/satellite6-db-upgrade-migrate.yaml
@@ -36,6 +36,7 @@
                 - 'ExpressScripts'
                 - 'Verizon'
                 - 'Walmart'
+                - 'CreditSuisse'
                 - 'Sat62RHEL6Migrate'
                 - 'CustomDbURL'
 
@@ -45,6 +46,7 @@
                 <p>For ExpressScript, <b>From version</b> should be <b>6.2</b> and OS should be <b>RHEL7</b></p>
                 <p>For Verizon, <b>From version</b> should be <b>6.2</b> and OS should be <b>RHEL7</b></p>
                 <p>For Walmart, <b> From version</b> should be <b>6.2</b> and OS should be <b>RHEL7</b></p>
+                <p>For CreditSuisse, <b> From version</b> should be <b>6.3</b> and OS should be <b>RHEL7</b></p>
                 <p>For Sat62RHEL6Migrate, <b>From version</b> should be <b>6.2</b> and OS should be <b>RHEL7</b></p>
                 <p>For CustomDbURL, You need to provide CUSTOM_DB_URL parameter, also specify From version and OS accordingly.</p>
         - string:


### PR DESCRIPTION
- Added support for 6.3 to 6.4 upgrade

- Added new db "CreditSuisse"

- Updated to consume master branch of satellite-clone for 6.3 and above versions(as it is having 6.3 support). 

- For upgrading satellite 6.1 and 6.2, will continue to use same 1.1.1 tag branch as it is stable.  
