### PR TITLE
Added support for upgrading puppet

### DIFF
--- a/jobs/satellite6-db-upgrade-migrate.yaml
+++ b/jobs/satellite6-db-upgrade-migrate.yaml
@@ -95,6 +95,11 @@
             description: |
                 <p>Un-Check if you do not want to perform upgrade post Satellite Clone or Migration</p>
         - bool:
+            name: PUPPET4_UPGRADE
+            default: false
+            description: |
+                <p>Check if satellite is 6.3 and you want to upgrade puppet3 to puppet4 before upgrading to 6.4.</p>
+        - bool:
             name: PERFORM_FOREMAN_MAINTAIN_UPGRADE
             default: false
             description: |

--- a/jobs/satellite6-upgrader.yaml
+++ b/jobs/satellite6-upgrader.yaml
@@ -82,6 +82,11 @@
             default: false
             description: |
                 <p>Check if you want to perform upgrade using Foreman-Maintain Tool.</p>
+        - bool:
+            name: PUPPET4_UPGRADE
+            default: false
+            description: |
+                <p>Check if satellite is 6.3 and you want to upgrade puppet3 to puppet4 before upgrading to 6.4.</p>
         - string:
             name: SATELLITE_HOSTNAME
             description: |

--- a/scripts/satellite6_db_upgrade_migrate.sh
+++ b/scripts/satellite6_db_upgrade_migrate.sh
@@ -138,6 +138,11 @@ fi
 
 export SATELLITE_HOSTNAME="${INSTANCE_NAME}"
 
+if [ "${PUPPET4_UPGRADE}" = "true" ]; then
+    # perform puppet3 to puppet4 upgrade
+    fab -H root@"${SATELLITE_HOSTNAME}" upgrade_puppet3_to_puppet4
+fi
+
 # Run satellite upgrade only when PERORM_UPGRADE flag is set.
 if [ "${PERFORM_UPGRADE}" = "true" ]; then
     # Sets up the satellite, capsule and clients on rhevm or personal boxes before upgrading

--- a/scripts/satellite6_upgrader.sh
+++ b/scripts/satellite6_upgrader.sh
@@ -30,6 +30,11 @@ if [ "${DISTRIBUTION}" = 'DOWNSTREAM' ]; then
     export TOOLS_URL_RHEL7="${TOOLS_RHEL7}"
 fi
 
+if [ "${PUPPET4_UPGRADE}" = "true" ]; then
+    # perform puppet3 to puppet4 upgrade
+    fab -H root@"${SATELLITE_HOSTNAME}" upgrade_puppet3_to_puppet4
+fi
+
 if [ "${PERFORM_FOREMAN_MAINTAIN_UPGRADE}" != "true" ]; then
     # Sets up the satellite, capsule and clients on rhevm or personal boxes before upgrading
     fab -u root setup_products_for_upgrade:"${UPGRADE_PRODUCT}","${OS}"


### PR DESCRIPTION
Earlier, we have to manually upgrade puppet3 to puppet4 and then we are able to perform satellite 6.3 to 6.4 upgrade. Now perform satellite 6.3 puppet 3 upgrade to 6.4 just by checking `PUPPET4_UPGRADE` parameter. 
This will also help in customer db upgrade automation where available db is of satellite 6.3 puppet 3 and you want to upgrade it to 6.4.

Depends on https://github.com/SatelliteQE/satellite6-upgrade/pull/180