### PR TITLE
 Make polarion jobs to push results easily during re-run

### DIFF
--- a/jobs/builders/satellite6_pull_artifacts_builders.yaml
+++ b/jobs/builders/satellite6_pull_artifacts_builders.yaml
@@ -1,0 +1,87 @@
+- builder:
+    name: satellite6-pull-artifacts-builders
+    builders:
+        - conditional-step:
+            condition-kind: and
+            condition-operands:
+                - condition-kind: regex-match
+                  regex: (true)
+                  label: ${{ENV,var="PULL_ARTIFACTS"}}
+                - condition-kind: regex-match
+                  regex: (tier1)
+                  label: ${{ENV,var="ENDPOINT"}}
+            steps:
+                - copyartifact:
+                    project: 'automation-{satellite_version}-tier1-{os}'
+                    filter: '*-results.xml'
+                    which-build: last-successful
+        - conditional-step:
+            condition-kind: and
+            condition-operands:
+                - condition-kind: regex-match
+                  regex: (true)
+                  label: ${{ENV,var="PULL_ARTIFACTS"}}
+                - condition-kind: regex-match
+                  regex: (tier2)
+                  label: ${{ENV,var="ENDPOINT"}}
+            steps:
+                - copyartifact:
+                    project: 'automation-{satellite_version}-tier2-{os}'
+                    filter: '*-results.xml'
+                    which-build: last-successful
+        - conditional-step:
+            condition-kind: and
+            condition-operands:
+                - condition-kind: regex-match
+                  regex: (true)
+                  label: ${{ENV,var="PULL_ARTIFACTS"}}
+                - condition-kind: regex-match
+                  regex: (tier3)
+                  label: ${{ENV,var="ENDPOINT"}}
+            steps:
+                - copyartifact:
+                    project: 'automation-{satellite_version}-tier3-{os}'
+                    filter: '*-results.xml'
+                    which-build: last-successful
+        - conditional-step:
+            condition-kind: and
+            condition-operands:
+                - condition-kind: regex-match
+                  regex: (true)
+                  label: ${{ENV,var="PULL_ARTIFACTS"}}
+                - condition-kind: regex-match
+                  regex: (tier4)
+                  label: ${{ENV,var="ENDPOINT"}}
+            steps:
+                - copyartifact:
+                    project: 'automation-{satellite_version}-tier4-{os}'
+                    filter: '*-results.xml'
+                    which-build: last-successful
+        - conditional-step:
+            condition-kind: and
+            condition-operands:
+                - condition-kind: regex-match
+                  regex: (true)
+                  label: ${{ENV,var="PULL_ARTIFACTS"}}
+                - condition-kind: regex-match
+                  regex: (rhai)
+                  label: ${{ENV,var="ENDPOINT"}}
+            steps:
+                - copyartifact:
+                    project: 'automation-{satellite_version}-rhai-{os}'
+                    filter: '*-results.xml'
+                    which-build: last-successful
+        - conditional-step:
+            condition-kind: and
+            condition-operands:
+                - condition-kind: regex-match
+                  regex: (true)
+                  label: ${{ENV,var="PULL_ARTIFACTS"}}
+                - condition-kind: regex-match
+                  regex: (destructive)
+                  label: ${{ENV,var="ENDPOINT"}}
+            steps:
+                - copyartifact:
+                    project: 'automation-{satellite_version}-destructive-{os}'
+                    filter: '*-results.xml'
+                    which-build: last-successful

--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -1323,6 +1323,7 @@
         - 'automation-{satellite_version}-rhai-{os}'
         - 'automation-{satellite_version}-destructive-{os}'
         - 'polarion-test-run-{satellite_version}-{os}'
+        - 'polarion-trigger-{satellite_version}-{os}'
         - 'report-automation-results-{satellite_version}-{os}'
         - 'report-consolidated-coverage-{satellite_version}-{os}'
         - 'automation-{satellite_version}-trigger-tiers-{os}'

--- a/jobs/satellite6-betelgeuse.yaml
+++ b/jobs/satellite6-betelgeuse.yaml
@@ -34,6 +34,83 @@
 
 
 - job-template:
+    name: polarion-trigger-{satellite_version}-{os}
+    project-type: multijob
+    node: sat6-{satellite_version}
+    parameters:
+        - string:
+            name: TEST_RUN_ID
+            description: |
+                'The resulting test run id is going to be suffixed with tierN '
+                'to differentiate between all tiers.'
+        - string:
+            name: POLARION_RELEASE
+    wrappers:
+        - build-name:
+            name: '#${{BUILD_NUMBER}} ${{ENV,var="TEST_RUN_ID"}}'
+    builders:
+        - multijob:
+            name: PhaseOne
+            condition: ALWAYS
+            projects:
+              - name: 'polarion-test-run-{satellite_version}-{os}'
+                predefined-parameters: |
+                  TEST_RUN_ID=${{TEST_RUN_ID}}
+                  POLARION_RELEASE=${{POLARION_RELEASE}}
+                  PULL_ARTIFACTS=true
+                  ENDPOINT=tier1
+        - multijob:
+            name: PhaseTwo
+            condition: ALWAYS
+            projects:
+              - name: 'polarion-test-run-{satellite_version}-{os}'
+                predefined-parameters: |
+                  TEST_RUN_ID=${{TEST_RUN_ID}}
+                  POLARION_RELEASE=${{POLARION_RELEASE}}
+                  PULL_ARTIFACTS=true
+                  ENDPOINT=tier2
+        - multijob:
+            name: PhaseThree
+            condition: ALWAYS
+            projects:
+              - name: 'polarion-test-run-{satellite_version}-{os}'
+                predefined-parameters: |
+                  TEST_RUN_ID=${{TEST_RUN_ID}}
+                  POLARION_RELEASE=${{POLARION_RELEASE}}
+                  PULL_ARTIFACTS=true
+                  ENDPOINT=tier3
+        - multijob:
+            name: PhaseFour
+            condition: ALWAYS
+            projects:
+              - name: 'polarion-test-run-{satellite_version}-{os}'
+                predefined-parameters: |
+                  TEST_RUN_ID=${{TEST_RUN_ID}}
+                  POLARION_RELEASE=${{POLARION_RELEASE}}
+                  PULL_ARTIFACTS=true
+                  ENDPOINT=tier4
+        - multijob:
+            name: PhaseFive
+            condition: ALWAYS
+            projects:
+              - name: 'polarion-test-run-{satellite_version}-{os}'
+                predefined-parameters: |
+                  TEST_RUN_ID=${{TEST_RUN_ID}}
+                  POLARION_RELEASE=${{POLARION_RELEASE}}
+                  PULL_ARTIFACTS=true
+                  ENDPOINT=rhai
+        - multijob:
+            name: PhaseSix
+            condition: ALWAYS
+            projects:
+              - name: 'polarion-test-run-{satellite_version}-{os}'
+                predefined-parameters: |
+                  TEST_RUN_ID=${{TEST_RUN_ID}}
+                  POLARION_RELEASE=${{POLARION_RELEASE}}
+                  PULL_ARTIFACTS=true
+                  ENDPOINT=destructive
+
+- job-template:
     name: polarion-test-run-{satellite_version}-{os}
     node: sat6-{satellite_version}
     scm:
@@ -54,8 +131,21 @@
                 'to differentiate between all tiers.'
         - string:
             name: POLARION_RELEASE
-        - string:
+        - choice:
             name: ENDPOINT
+            choices:
+                 - 'none'
+                 - 'tier1'
+                 - 'tier2'
+                 - 'tier3'
+                 - 'tier4'
+                 - 'rhai'
+                 - 'destructive'
+        - bool:
+            name: PULL_ARTIFACTS
+            default: false
+            description: |
+                'Required only when manually triggering the job.'
     wrappers:
         - inject-passwords:
             global: true
@@ -66,6 +156,9 @@
             properties-content: |
                 SATELLITE_VERSION={satellite_version}
     builders:
+        - satellite6-pull-artifacts-builders:
+            satellite_version: "{satellite_version}"
+            os: "{os}"
         - shining-panda:
             build-environment: virtualenv
             name: betelgeuse


### PR DESCRIPTION
Added support so that jobs can easily pull in artifacts
parse them and upload results to polarion.

Up until now, the tier jobs used to trigger the polarion
jobs with right set of values and there was no easy way
to re-run these jobs.

With this PR it would help us to easily re-run the jobs.

Signed-off-by: Kedar Bidarkar <kbidarka@redhat.com>