### PR TITLE
katello-installer tests shouldn't set branch

### DIFF
--- a/workflows/test/katelloInstaller.groovy
+++ b/workflows/test/katelloInstaller.groovy
@@ -14,7 +14,7 @@ node('rvm') {
             gitlabCommitStatus {
                 withRVM(["gem install bundler"])
                 withRVM(["bundle install"])
-                withRVM(["FOREMAN_BRANCH=1.15-stable bundle exec rake"])
+                withRVM(["bundle exec rake"])
             }
 
         } finally {


### PR DESCRIPTION
The Rakefile for each version should indicate the proper Foreman branch.