### PR TITLE
Revert "Run Upgrade tests for 6.3 without saucelabs"

### DIFF
--- a/scripts/satellite6-upgrade-tier-source.sh
+++ b/scripts/satellite6-upgrade-tier-source.sh
@@ -23,11 +23,6 @@ if [[ "${SATELLITE_VERSION}" == "6.4" ]]; then
         PYTHONHASHSEED=0
 fi
 
-# Temporary change to check test performance without saucelabs
-if [[ "${SATELLITE_VERSION}" == "6.3" ]]; then
-    SAUCE_PLATFORM="no_saucelabs"
-fi
-
 if [[ "${SAUCE_PLATFORM}" != "no_saucelabs" ]]; then
     echo "The Sauce Tunnel Identifier for Server Hostname ${SERVER_HOSTNAME} is ${TUNNEL_IDENTIFIER}"
     sed -i "s/^browser.*/browser=saucelabs/" robottelo.properties


### PR DESCRIPTION
Reverts SatelliteQE/robottelo-ci#1222

The results don't look good without sauce, so reverting to sauce and will identify the actual causes for test timeouts