### PR TITLE
Fixes the default satellite installation version message 

### DIFF
--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -27,7 +27,7 @@
             description: |
                 <p>Choose the distribution type:</p>
                 <ul>
-                  <li><strong>INTERNALAK</strong>: Install Satellite6.3 via AK from latest stable internal compose</li>
+                  <li><strong>INTERNALAK</strong>: Install Satellite 6.4 via AK from latest stable internal compose</li>
                   <li><strong>INTERNAL</strong>: Install Satellite6 from latest stable internal compose</li>
                   <li><strong>INTERNALREPOFILE</strong>: Install Satellite6.3 via REPOFILE from latest stable internal compose</li>
                   <li><strong>GA</strong>: Install from CDN</li>


### PR DESCRIPTION
minor change that i tried to do.
The satellite6-Installer.yaml file had INSTALLERAK showing the message Default satellite installation version 6.3 where as actually default version was 6.4