### PR TITLE
fix sed expression for replacing cdn=BOOL value not to leak elsewhere

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -91,7 +91,7 @@ fi
 # Sync content and use the below repos only when DISTRIBUTION is not GA
 if [[ "${SATELLITE_DISTRIBUTION}" != *"GA"* ]]; then
     # The below cdn flag is required by automation to flip between RH & custom syncs.
-    sed -i "s/cdn.*/cdn=false/" robottelo.properties
+    sed -i "s/^cdn=.*/cdn=false/" robottelo.properties
     # Usage of '|' is intentional as TOOLS_REPO can bring in http url which has '/'
     sed -i "s|sattools_repo=.*|sattools_repo=rhel7=${RHEL7_TOOLS_REPO},rhel6=${RHEL6_TOOLS_REPO}|" robottelo.properties
     sed -i "s|capsule_repo=.*|capsule_repo=${CAPSULE_REPO}|" robottelo.properties

--- a/scripts/satellite6-upgrade-tier-source.sh
+++ b/scripts/satellite6-upgrade-tier-source.sh
@@ -98,7 +98,7 @@ fi
 # Sync content and use the below repos only when DISTRIBUTION is not GA
 if [[ "${SATELLITE_DISTRIBUTION}" != *"GA"* ]]; then
     # The below cdn flag is required by automation to flip between RH & custom syncs.
-    sed -i "s/cdn.*/cdn=false/" robottelo.properties
+    sed -i "s/^cdn=.*/cdn=false/" robottelo.properties
     # Usage of '|' is intentional as TOOLS_REPO can bring in http url which has '/'
     sed -i "s|sattools_repo=.*|sattools_repo=rhel7=${RHEL7_TOOLS_REPO},rhel6=${RHEL6_TOOLS_REPO}|" robottelo.properties
     sed -i "s|capsule_repo=.*|capsule_repo=${CAPSULE_REPO}|" robottelo.properties


### PR DESCRIPTION
the current implementation replaces any firsdt occurrence of `cdn*` which is quite generic and misfires at wrong target, e.g. if we have a cdn word in the repo url specified before the `cdn=false` occurrence.

true story:
```
ansible_repo=http://cdn=false
```

this makes the pattern more specific to target the specific option only.
```bash
$ sed "s/^cdn=.*/cdn=false/" robottelo.properties  | grep cdn
cdn=false
ansible_repo=http://cdn.foo.bar/a/b/c
```