### PR TITLE
Added support to populate n-1 clients repo

### DIFF
--- a/jobs/satellite6-client-populate.yaml
+++ b/jobs/satellite6-client-populate.yaml
@@ -122,6 +122,11 @@
             default: true
             description: |
                 If set to true, will populate the different client architecture repos to the Satellite6 Server for further client testing.
+        - bool:
+            name: NMINUSONE
+            default: false
+            description: |
+                If set to true, will populate N-1 client repos ex: testing 6.3 clients with 6.4 satellite.
     scm:
         - git:
             url: https://github.com/SatelliteQE/automation-tools.git

--- a/scripts/satellite6-configure.sh
+++ b/scripts/satellite6-configure.sh
@@ -30,3 +30,12 @@ else
     cp ${PWD}/scripts/satellite6-populate-template.sh satellite6-populate.sh
     chmod 755 satellite6-populate.sh
 fi
+
+
+if [[ -n "${NMINUSONE}" ]]; then
+    if [[ "${SATELLITE_VERSION}" = "6.4" ]]; then
+        export SATELLITE_VERSION=6.3
+    elif [[ "${SATELLITE_VERSION}" = "6.3" ]]; then
+        export SATELLITE_VERSION=6.2
+    fi
+fi


### PR DESCRIPTION
This parameter will help to setup and test n-1 client i.e.  test 6.3 clients with 6.4 satellite