### PR TITLE
Don't run UI smoke tests for upgrades for 6.4

### DIFF
--- a/scripts/satellite6-upgrade-tier-source.sh
+++ b/scripts/satellite6-upgrade-tier-source.sh
@@ -127,9 +127,12 @@ if [ "${ENDPOINT}" != "end-to-end" ]; then
 elif [ "${ENDPOINT}" == "end-to-end" ]; then
     set +e
     # Run end-to-end , also known as smoke tests
-    $(which py.test) -v --junit-xml="smoke-tests-results.xml" tests/foreman/endtoend
+    if [[ "${SATELLITE_VERSION}" != "6.1" && "${SATELLITE_VERSION}" != "6.2" && "${SATELLITE_VERSION}" != "6.3" ]]; then
+        $(which py.test) -v --junit-xml="smoke-tests-results.xml" tests/foreman/endtoend/test_{api,cli}_endtoend.py
+    else
+        $(which py.test) -v --junit-xml="smoke-tests-results.xml" tests/foreman/endtoend
+    fi
     set -e
-
 else
     make test-foreman-${ENDPOINT} PYTEST_XDIST_NUMPROCESSES=${ROBOTTELO_WORKERS}
 fi


### PR DESCRIPTION
```
pytest --collect-only tests/foreman/endtoend/test_{api,cli}_endtoend.py
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.5.3, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/sjagtap/PycharmProjects/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collecting 11 items                                                                                                                                                                                               2018-08-21 14:37:32 - conftest - DEBUG - Collected 11 test cases

collected 11 items                                                                                                                                                                                                
<Module 'tests/foreman/endtoend/test_api_endtoend.py'>
  <UnitTestCase 'AvailableURLsTestCase'>
    <TestCaseFunction 'test_positive_get_links'>
    <TestCaseFunction 'test_positive_get_status_code'>
  <UnitTestCase 'EndToEndTestCase'>
    <TestCaseFunction 'test_positive_end_to_end'>
    <TestCaseFunction 'test_positive_find_admin_user'>
    <TestCaseFunction 'test_positive_find_default_loc'>
    <TestCaseFunction 'test_positive_find_default_org'>
    <TestCaseFunction 'test_positive_ping'>
<Module 'tests/foreman/endtoend/test_cli_endtoend.py'>
  <UnitTestCase 'EndToEndTestCase'>
    <TestCaseFunction 'test_positive_end_to_end'>
    <TestCaseFunction 'test_positive_find_admin_user'>
    <TestCaseFunction 'test_positive_find_default_loc'>
    <TestCaseFunction 'test_positive_find_default_org'>

=======================================================================================
```