### PR TITLE
added -o junit_suite_name to the py.tet arguments

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -111,11 +111,13 @@ elif [ "${ENDPOINT}" != "rhai" ]; then
     set +e
     # Run sequential tests
     $(which py.test) -v --junit-xml="${ENDPOINT}-sequential-results.xml" \
+        -o junit_suite_name="${ENDPOINT}-sequential" \
         -m "${ENDPOINT} and run_in_one_thread and not stubbed" \
         ${TEST_TYPE}
 
     # Run parallel tests
     $(which py.test) -v --junit-xml="${ENDPOINT}-parallel-results.xml" -n "${ROBOTTELO_WORKERS}" \
+        -o junit_suite_name="${ENDPOINT}-parallel" \
         -m "${ENDPOINT} and not run_in_one_thread and not stubbed" \
         ${TEST_TYPE}
     set -e

--- a/scripts/satellite6-standalone-automation.sh
+++ b/scripts/satellite6-standalone-automation.sh
@@ -55,7 +55,7 @@ if [[ "${SAUCE_PLATFORM}" != "no_saucelabs" ]]; then
 fi
 
 pytest() {
-    $(which py.test) -v --junit-xml=foreman-results.xml -m "${PYTEST_MARKS}" "$@"
+    $(which py.test) -v --junit-xml=foreman-results.xml -o junit_suite_name=standalone-automation -m "${PYTEST_MARKS}" "$@"
 }
 
 if [ -n "${PYTEST_OPTIONS:-}" ]; then

--- a/scripts/satellite6-upgrade-existence.sh
+++ b/scripts/satellite6-upgrade-existence.sh
@@ -2,9 +2,9 @@
 pip install -r requirements.txt
 set +e
 export ENDPOINT='cli'
-$(which py.test) -v --continue-on-collection-errors --junit-xml=test_existance_cli-results.xml upgrade_tests/test_existance_relations/cli/
+$(which py.test) -v --continue-on-collection-errors --junit-xml=test_existance_cli-results.xml -o junit_suite_name=test_existance_cli upgrade_tests/test_existance_relations/cli/
 export ENDPOINT='api'
-$(which py.test) -v --continue-on-collection-errors --junit-xml=test_existance_api-results.xml upgrade_tests/test_existance_relations/api/
+$(which py.test) -v --continue-on-collection-errors --junit-xml=test_existance_api-results.xml -o junit_suite_name=test_existance_api upgrade_tests/test_existance_relations/api/
 set -e
 
 echo

--- a/scripts/satellite6-upgrade-run-scenarios.sh
+++ b/scripts/satellite6-upgrade-run-scenarios.sh
@@ -20,13 +20,13 @@ fi
 
 # Run pre-upgarde scenarios tests
 if [ ${ENDPOINT} == 'pre-upgrade' ]; then
-    $(which py.test)  -v --continue-on-collection-errors -s -m pre_upgrade --junit-xml=test_scenarios-pre-results.xml upgrade_tests/test_scenarios/
+    $(which py.test)  -v --continue-on-collection-errors -s -m pre_upgrade --junit-xml=test_scenarios-pre-results.xml -o junit_suite_name=test_scenarios-pre upgrade_tests/test_scenarios/
     # Creates the pre-upgrade data-store required for existence tests
     echo "Setting up pre-upgrade data-store for existence tests"
     fab -u root set_datastore:"preupgrade","cli"
     fab -u root set_datastore:"preupgrade","api"
 else
-    $(which py.test) -v --continue-on-collection-errors -s -m post_upgrade --junit-xml=test_scenarios-post-results.xml upgrade_tests/test_scenarios/
+    $(which py.test) -v --continue-on-collection-errors -s -m post_upgrade --junit-xml=test_scenarios-post-results.xml -o junit_suite_name=test_scenarios-post upgrade_tests/test_scenarios/
     # Delete the Original Manifest from the box to run robottelo tests
     fab -u root -H $SERVER_HOSTNAME delete_manifest:"Default Organization"
 fi

--- a/scripts/satellite6-upgrade-tier-source.sh
+++ b/scripts/satellite6-upgrade-tier-source.sh
@@ -116,11 +116,13 @@ if [ "${ENDPOINT}" != "end-to-end" ]; then
     set +e
     # Run all tiers sequential tests with upgrade mark
     $(which py.test) -v --junit-xml="${ENDPOINT}-upgrade-sequential-results.xml" \
+        -o junit_suite_name="${ENDPOINT}-upgrade-sequential" \
         -m "upgrade and run_in_one_thread and not stubbed" \
         ${TEST_TYPE}
 
     # Run all tiers parallel tests with upgrade mark
     $(which py.test) -v --junit-xml="${ENDPOINT}-upgrade-parallel-results.xml" -n "${ROBOTTELO_WORKERS}" \
+        -o junit_suite_name="${ENDPOINT}-upgrade-parallel" \
         -m "upgrade and not run_in_one_thread and not stubbed" \
         ${TEST_TYPE}
     set -e
@@ -128,9 +130,9 @@ elif [ "${ENDPOINT}" == "end-to-end" ]; then
     set +e
     # Run end-to-end , also known as smoke tests
     if [[ "${SATELLITE_VERSION}" != "6.1" && "${SATELLITE_VERSION}" != "6.2" && "${SATELLITE_VERSION}" != "6.3" ]]; then
-        $(which py.test) -v --junit-xml="smoke-tests-results.xml" tests/foreman/endtoend/test_{api,cli}_endtoend.py
+        $(which py.test) -v --junit-xml="smoke-tests-results.xml" -o junit_suite_name="smoke-tests" tests/foreman/endtoend/test_{api,cli}_endtoend.py
     else
-        $(which py.test) -v --junit-xml="smoke-tests-results.xml" tests/foreman/endtoend
+        $(which py.test) -v --junit-xml="smoke-tests-results.xml" -o junit_suite_name="smoke-tests" tests/foreman/endtoend
     fi
     set -e
 else

--- a/scripts/satellite6_db_upgrade_migrate.sh
+++ b/scripts/satellite6_db_upgrade_migrate.sh
@@ -193,7 +193,7 @@ if [ "${PERFORM_UPGRADE}" = "true" ]; then
     fab -u root product_upgrade:"${UPGRADE_PRODUCT}"
     # Run existance tests
     if [ "${RUN_EXISTENCE_TESTS}" == 'true' ]; then
-        $(which py.test) -v --junit-xml=test_existance-results.xml upgrade_tests/test_existance_relations/
+        $(which py.test) -v --junit-xml=test_existance-results.xml -o junit_suite_name=test_existance upgrade_tests/test_existance_relations/
     fi
     # Post Upgrade archive logs from log analyzer tool
     if [ -d upgrade-diff-logs ]; then

--- a/scripts/satellite6_upgrader.sh
+++ b/scripts/satellite6_upgrader.sh
@@ -41,7 +41,7 @@ fab -u root setup_products_for_upgrade:"${UPGRADE_PRODUCT}","${OS}"
 set +e
 # Run pre-upgarde scenarios tests
 if [ "${RUN_SCENARIO_TESTS}" == 'true' ]; then
-    $(which py.test) -v -s -m pre_upgrade --junit-xml=test_scenarios-pre-results.xml upgrade_tests/test_scenarios/
+    $(which py.test) -v -s -m pre_upgrade --junit-xml=test_scenarios-pre-results.xml -o junit_suite_name=test_scenarios-pre upgrade_tests/test_scenarios/
 fi
 set -e
 
@@ -97,7 +97,7 @@ fi
 set +e
 # Run post-upgarde scenarios tests
 if [ "${RUN_SCENARIO_TESTS}" == 'true' ]; then
-    $(which py.test) -v -s -m post_upgrade --junit-xml=test_scenarios-post-results.xml upgrade_tests/test_scenarios/
+    $(which py.test) -v -s -m post_upgrade --junit-xml=test_scenarios-post-results.xml -o junit_suite_name=test_scenarios-post upgrade_tests/test_scenarios/
 fi
 set -e
 
@@ -111,10 +111,10 @@ export BUGZILLA_ENVIRON_SAT_VERSION="${TO_VERSION}"
 if [ "${RUN_EXISTANCE_TESTS}" == 'true' ]; then
     set +e
     export ENDPOINT='cli'
-    $(which py.test) -v --continue-on-collection-errors --junit-xml=test_existance_cli-results.xml upgrade_tests/test_existance_relations/cli/
+    $(which py.test) -v --continue-on-collection-errors --junit-xml=test_existance_cli-results.xml -o junit_suite_name=test_existance_cli upgrade_tests/test_existance_relations/cli/
 
     export ENDPOINT='api'
-    $(which py.test) -v --continue-on-collection-errors --junit-xml=test_existance_api-results.xml upgrade_tests/test_existance_relations/api/
+    $(which py.test) -v --continue-on-collection-errors --junit-xml=test_existance_api-results.xml -o junit_suite_name=test_existance_api upgrade_tests/test_existance_relations/api/
     set -e
 fi
 


### PR DESCRIPTION
added `-o junit_suite_name` to the `py.test` arguments test_suite name in the resulting xml.
this is usefulf for importing launches to the `report portal`

```
$ py.test --junit-xml=foo.xml
===== test session starts=====
...
===== 1 error in 0.84 seconds =====
```

$ head foo.xml 
`<?xml version="1.0" encoding="utf-8"?><testsuite errors="1" failures="0" name="pytest" `

```
$ py.test --junit-xml=foo.xml -o junit_suite_name=fero
===== test session starts=====
...
===== 1 error in 0.85 seconds =====
```

$ head foo.xml 
`<?xml version="1.0" encoding="utf-8"?><testsuite errors="1" failures="0" name="fero" `

