### PR TITLE
ignore npm install failure instead of using --ignore-scripts

### DIFF
--- a/workflows/test/foreman-lib.groovy
+++ b/workflows/test/foreman-lib.groovy
@@ -53,7 +53,7 @@ def setup_foreman(ruby = '2.2') {
     if (fileExists('package.json')) {
         steps['node'] = {
             sh 'npm install npm@\\<"5.0.0"'
-            sh './node_modules/.bin/npm install --no-optional --ignore-scripts --global-style true'
+            sh './node_modules/.bin/npm install --no-optional --global-style true || true'
             sh 'npm install phantomjs'
         }
     }


### PR DESCRIPTION
`npm install` in foreman fails in the postinstall script, if the ruby
environment is not prepared yet. the original idea was to run it with
--ignore-scripts, thus ignoring the postinstall script, and then
re-running it again after the ruby environment is ready.

however, --ignore-scripts ignores the scripts of ALL node modules, but a
second `npm install` only re-runs the scripts of Foreman, not of its
dependencies.

instead call `npm install || true` thus ignoring that `npm install`
bailed out, hoping that it bailed in the Foreman postinstall script,
which will be executed on the next `npm install` run.