### PR TITLE
Add support for VMware Compute Resource prov.

### DIFF
--- a/scripts/satellite6-configure-variables.sh
+++ b/scripts/satellite6-configure-variables.sh
@@ -28,6 +28,12 @@ sed -i "s|RHEV_USERNAME=.*|RHEV_USERNAME=\"${RHEV_USER}\"|" satellite6-populate.
 sed -i "s|RHEV_PASSWORD=.*|RHEV_PASSWORD=\"${RHEV_PASSWD}\"|" satellite6-populate.sh
 sed -i "s|RHEV_DATACENTER_UUID=.*|RHEV_DATACENTER_UUID=\"${RHEV_DATACENTER_UUID}\"|" satellite6-populate.sh
 
+# Populate the VMware CR information.
+sed -i "s|VMWARE_URL=.*|VMWARE_URL=\"${VMWARE_URL}\"|" satellite6-populate.sh
+sed -i "s|VMWARE_USERNAME=.*|VMWARE_USERNAME=\"${VMWARE_USERNAME}\"|" satellite6-populate.sh
+sed -i "s|VMWARE_PASSWORD=.*|VMWARE_PASSWORD=\"${VMWARE_PASSWORD}\"|" satellite6-populate.sh
+sed -i "s|VMWARE_DATACENTER=.*|VMWARE_DATACENTER=\"${VMWARE_DATACENTER}\"|" satellite6-populate.sh
+
 # Populate the OSP CR Information.
 sed -i "s|OS_URL=.*|OS_URL=\"${OS_URL}\"|" satellite6-populate.sh
 sed -i "s|OS_USERNAME=.*|OS_USERNAME=\"${OS_USERNAME}\"|" satellite6-populate.sh
@@ -91,4 +97,3 @@ if [[ "${ONLY_POPULATE_TEMPLATE}" = 'true' ]]; then
 else
     ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@"${SERVER_HOSTNAME}" /root/satellite6-populate.sh
 fi
-

--- a/scripts/satellite6-populate-template.sh
+++ b/scripts/satellite6-populate-template.sh
@@ -39,6 +39,17 @@ if [[ -z "$OS_URL" || -z "$OS_USERNAME" || -z "$OS_PASSWORD" ]]; then
     exit 1
 fi
 
+# VMware Compute Resource
+COMPUTE_RESOURCE_NAME_VMWARE="VMware"
+VMWARE_URL=""
+VMWARE_USERNAME=""
+VMWARE_PASSWORD=""
+VMWARE_DATACENTER=""
+
+if [[ -z "$VMWARE_URL" || -z "$VMWARE_USERNAME" || -z "$VMWARE_PASSWORD" || -z "$VMWARE_DATACENTER" ]]; then
+    echo "You need to specify VMWARE_URL, VMWARE_USERNAME, VMWARE_PASSWORD, VMWARE_DATACENTER to be used as Compute Resource."
+    exit 1
+fi
 
 # The below values get populated from the satellite6_libvirt_install.conf file.
 # DOMAIN and SUBNET Variables.
@@ -386,6 +397,9 @@ elif [ "${SAT_VERSION}" == "6.3" ]; then
 elif [ "${SAT_VERSION}" == "6.4" ]; then
     (satellite_runner compute-resource create --provider Ovirt --url "${RHEV_URL}" --name "rhevm1" --user "${RHEV_USERNAME}" --password "${RHEV_PASSWORD}" --location-ids "${LOC}" --organization-ids "${ORG}" --datacenter "${RHEV_DATACENTER_UUID}" --use-v4 true) || true
 fi
+
+# Create VMware CR
+satellite_runner compute-resource create --name "${COMPUTE_RESOURCE_NAME_VMWARE}" --provider VMware --server "${VMWARE_URL}" --location-ids "${LOC}" --organization-ids "${ORG}" --datacenter "${VMWARE_DATACENTER}" --user "${VMWARE_USERNAME}" --password "${VMWARE_PASSWORD}"
 
 # Create OpenStack CR
 # satellite_runner compute-resource create --name openstack_provider --provider Openstack --url "${OS_URL}" --location-ids "${LOC}" --organization-ids "${ORG}" --user "${OS_USERNAME}" --password "${OS_PASSWORD}"

--- a/scripts/satellite6-provision-host-template.sh
+++ b/scripts/satellite6-provision-host-template.sh
@@ -1,6 +1,7 @@
 
 RHEL7_LIBVIRT_HOST="rhel-7-libvirt"
 RHEL6_LIBVIRT_HOST="rhel-6-libvirt"
+VMWARE_HOST="rhel-7-vmware"
 
 # Provision a host with Libvirt Provider.
 satellite_runner host create --name="${RHEL7_LIBVIRT_HOST}" --root-password='changeme' --organization-id="${ORG}" --location-id="${LOC}" --hostgroup="RHEL 7 Server 64-bit HG" --compute-resource="$COMPUTE_RESOURCE_NAME_LIBVIRT" --compute-attributes="cpus=1, memory=1073741824, start=1" --interface="primary=true, compute_type=bridge, compute_bridge=${SUBNET_NAME}, compute_model=virtio" --volume="capacity=10G,format_type=qcow2"
@@ -25,3 +26,11 @@ sleep 1200
 satellite_runner host delete --name "${RHEL7_LIBVIRT_HOST}.${DOMAIN_NAME}"
 
 satellite_runner host delete --name "${RHEL6_LIBVIRT_HOST}.${DOMAIN_NAME}"
+
+# Provision a host with VMware Provider.
+satellite_runner host create --name="${VMWARE_HOST}" --root-password='changeme' --domain-id "${DOMAIN_ID}" --subnet "${SUBNET_NAME}" --organization-id="${ORG}" --build true --location-id="${LOC}" --hostgroup="RHEL 7 Server 64-bit HG" --provision-method build --compute-resource="$COMPUTE_RESOURCE_NAME_VMWARE" --interface="managed=true,primary=true,provision=true,compute_type=VirtualE1000,compute_network=\"qe_${SUBNET_NAME}\"" --volume="size_gb=20G,datastore=Local-Ironforge,name=myharddisk,thin=true,eager_zero=false,mode=persistent" --compute-attributes="cpus=1,corespersocket=2,memory_mb=4096,cluster=Satellite_Engineering,path=/Datacenters/RH_Engineering/vm,start=1"
+
+# This sleep is needed, because of the provisioning phase during this period.
+sleep 1200
+
+satellite_runner host delete --name "${VMWARE_HOST}.${DOMAIN_NAME}"


### PR DESCRIPTION
Tested this with hammer on my sat and confirmed it works:

```
hammer> host create --name test235 --location-id 2 --organization-id 1 --hostgroup-id 1 --subnet-id 1 --domain-id 1 --build true --provision-method build --compute-resource-id 1 --interface="managed=true,primary=true,provision=true,compute_type=VirtualE1000,compute_network=qe_sat6major_el6" --volume="size_gb=20G,datastore=Local-Ironforge,name=myharddisk,thin=true,eager_zero=false,mode=persistent" --compute-attributes="cpus=1,corespersocket=2,memory_mb=4096,cluster=Satellite_Engineering,path=/Datacenters/RH_Engineering/vm,start=1"
Host created
```