### PR TITLE
archive the current state when releasing to QA

### DIFF
--- a/jobs/release/sat-63-release-qa.yaml
+++ b/jobs/release/sat-63-release-qa.yaml
@@ -5,9 +5,6 @@
       - string:
           name: snapVersion
           description: "Snap release version"
-      - string:
-          name: previousSnapVersion
-          description: "Previous snap release version"
     dsl:
       !include-raw:
         - workflows/6.3/releasePipelineAttributes.groovy

--- a/jobs/release/sat-64-release-qa.yaml
+++ b/jobs/release/sat-64-release-qa.yaml
@@ -5,9 +5,6 @@
       - string:
           name: snapVersion
           description: "Snap release version"
-      - string:
-          name: previousSnapVersion
-          description: "Previous snap release version"
     dsl:
       !include-raw:
         - workflows/6.4/releasePipelineAttributes.groovy

--- a/jobs/release/sat-65-release-qa.yaml
+++ b/jobs/release/sat-65-release-qa.yaml
@@ -5,9 +5,6 @@
       - string:
           name: snapVersion
           description: "Snap release version"
-      - string:
-          name: previousSnapVersion
-          description: "Previous snap release version"
     dsl:
       !include-raw:
         - workflows/6.5/releasePipelineAttributes.groovy

--- a/jobs/release/sat-maintenance-next-release-qa.yaml
+++ b/jobs/release/sat-maintenance-next-release-qa.yaml
@@ -5,9 +5,6 @@
       - string:
           name: snapVersion
           description: "Snap release version"
-      - string:
-          name: previousSnapVersion
-          description: "Previous snap release version"
     dsl:
       !include-raw:
         - workflows/maintenance-next/releasePipelineAttributes.groovy

--- a/jobs/release/sat-maintenance-release-qa.yaml
+++ b/jobs/release/sat-maintenance-release-qa.yaml
@@ -5,9 +5,6 @@
       - string:
           name: snapVersion
           description: "Snap release version"
-      - string:
-          name: previousSnapVersion
-          description: "Previous snap release version"
     dsl:
       !include-raw:
         - workflows/maintenance/releasePipelineAttributes.groovy

--- a/workflows/releaseQAWorkflow.groovy
+++ b/workflows/releaseQAWorkflow.groovy
@@ -6,79 +6,6 @@ node('sat6-build') {
 
     }
 
-    stage("Create Archive Environment") {
-
-        // Remove old package report
-        sh 'rm -rf package_report.yaml'
-
-        if (previousSnapVersion) {
-            // Work around for parameters not being accessible in functions
-            writeFile file: 'previous_snap', text: previousSnapVersion
-            def version = readFile 'previous_snap'
-
-            createLifecycleEnvironment {
-                name = version
-                prior = 'Library'
-                organization = 'Sat6-CI'
-            }
-        }
-    }
-
-    stage("Archive Satellite") {
-
-        if (previousSnapVersion) {
-            // Work around for parameters not being accessible in functions
-            writeFile file: 'previous_snap', text: previousSnapVersion
-            def version = readFile 'previous_snap'
-
-            satellite_composite_content_views.each { cv ->
-              promoteContentView {
-                organization = 'Sat6-CI'
-                content_view = cv
-                from_lifecycle_environment = 'QA'
-                to_lifecycle_environment = version
-              }
-            }
-        }
-    }
-
-    stage("Archive Capsule") {
-
-        if (previousSnapVersion) {
-            // Work around for parameters not being accessible in functions
-            writeFile file: 'previous_snap', text: previousSnapVersion
-            def version = readFile 'previous_snap'
-
-            capsule_composite_content_views.each { cv ->
-              promoteContentView {
-                organization = 'Sat6-CI'
-                content_view = cv
-                from_lifecycle_environment = 'QA'
-                to_lifecycle_environment = version
-              }
-            }
-        }
-    }
-
-    stage("Archive Tools") {
-
-        if (previousSnapVersion) {
-            // Work around for parameters not being accessible in functions
-            writeFile file: 'previous_snap', text: previousSnapVersion
-            def version = readFile 'previous_snap'
-
-            tools_composite_content_views.each { cv ->
-              promoteContentView {
-                organization = 'Sat6-CI'
-                content_view = cv
-                from_lifecycle_environment = 'QA'
-                to_lifecycle_environment = version
-              }
-            }
-        }
-
-    }
-
     stage("Promote Satellite to QA") {
 
       satellite_composite_content_views.each { cv ->
@@ -136,6 +63,72 @@ node('sat6-build') {
       }
 
     }
+
+    stage("Create Archive Environment") {
+
+      // Work around for parameters not being accessible in functions
+      writeFile file: 'snap_version', text: snapVersion
+      def version = readFile 'snap_version'
+
+      createLifecycleEnvironment {
+          name = version
+          prior = 'Library'
+          organization = 'Sat6-CI'
+      }
+
+    }
+
+    stage("Archive Satellite") {
+
+      // Work around for parameters not being accessible in functions
+      writeFile file: 'snap_version', text: snapVersion
+      def version = readFile 'snap_version'
+
+      satellite_composite_content_views.each { cv ->
+        promoteContentView {
+          organization = 'Sat6-CI'
+          content_view = cv
+          from_lifecycle_environment = 'QA'
+          to_lifecycle_environment = version
+        }
+      }
+
+    }
+
+    stage("Archive Capsule") {
+
+      // Work around for parameters not being accessible in functions
+      writeFile file: 'snap_version', text: snapVersion
+      def version = readFile 'snap_version'
+
+      capsule_composite_content_views.each { cv ->
+        promoteContentView {
+          organization = 'Sat6-CI'
+          content_view = cv
+          from_lifecycle_environment = 'QA'
+          to_lifecycle_environment = version
+        }
+      }
+
+    }
+
+    stage("Archive Tools") {
+
+      // Work around for parameters not being accessible in functions
+      writeFile file: 'snap_version', text: snapVersion
+      def version = readFile 'snap_version'
+
+      tools_composite_content_views.each { cv ->
+        promoteContentView {
+          organization = 'Sat6-CI'
+          content_view = cv
+          from_lifecycle_environment = 'QA'
+          to_lifecycle_environment = version
+        }
+      }
+
+    }
+
 }
 
 node {


### PR DESCRIPTION
instead of archiving the *previous* snap, archive the currently released
one. this allows us to drop the previousSnapVersion parameter. it also
makes the new snap directly available under its number and opens up the
possibility to have an AK pointing to the exact snap directly after
release.

Note: before merging this, we'd have to manually archive the currently
released snaps, as otherwise those would be lost.