### PR TITLE
Fix issue with packaging job after jenkins upgrade

### DIFF
--- a/workflows/lib/packaging.groovy
+++ b/workflows/lib/packaging.groovy
@@ -124,7 +124,7 @@ node('sat6-build') {
 
             setup_obal()
 
-            gitlabCommitStatus(build_type) {
+            gitlabCommitStatus(name: build_type) {
                 withEnv(["KRB5CCNAME=${krbcc}"]) {
                     obal(
                         action: build_type,


### PR DESCRIPTION
Fixes the below issue on scratch builds

	java.lang.IllegalArgumentException: Expected named arguments but got scratch