### PR TITLE
Block tier jobs for pipeline that receive z-stream only

### DIFF
--- a/jobs/parameters/satellite6_provisioning_parameters.yaml
+++ b/jobs/parameters/satellite6_provisioning_parameters.yaml
@@ -73,3 +73,8 @@
                 - 'edge'
                 - 'internet explorer'
             description: 'Specify the Sauce Browser to use along with Sauce Platform.'
+        - string:
+            name: START_TIER
+            default: 'false'
+            description: |
+                <p>Running z-stream is by-default paused for Jobs. This variable has no effect on latest Major Downstream Version and Pipeline</p>

--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -74,25 +74,55 @@
             properties-file: build_env.properties
         - trigger-builds:
             - project: 'satellite6-manifest-downloader'
-        - trigger-builds:
-            - project: 'automation-{satellite_version}-trigger-tiers-{os}'
-              predefined-parameters: |
-                SERVER_HOSTNAME=${{SERVER_HOSTNAME}}
-                SATELLITE_DISTRIBUTION=${{SATELLITE_DISTRIBUTION}}
-                RHEL6_TOOLS_REPO=${{RHEL6_TOOLS_REPO}}
-                RHEL7_TOOLS_REPO=${{RHEL7_TOOLS_REPO}}
-                CAPSULE_REPO=${{CAPSULE_REPO}}
-                SUBNET=${{SUBNET}}
-                NETMASK=${{NETMASK}}
-                GATEWAY=${{GATEWAY}}
-                BRIDGE=${{BRIDGE}}
-                BUILD_LABEL=${{BUILD_LABEL}}
-                DISCOVERY_ISO=${{DISCOVERY_ISO}}
-                ROBOTTELO_WORKERS=${{ROBOTTELO_WORKERS}}
-                IMAGE=${{IMAGE}}
-                SAUCE_BROWSER=${{SAUCE_BROWSER}}
-                SAUCE_PLATFORM=${{SAUCE_PLATFORM}}
-                RUBY_CODE_COVERAGE=${{RUBY_CODE_COVERAGE}}
+        - conditional-step:
+                    condition-kind: strings-match
+                    condition-string1: 'true'
+                    condition-string2: ${{ENV,var="START_TIER"}}
+                    condition-case-insensitive: true
+                    steps:
+                    - trigger-builds:
+                      - project: 'automation-{satellite_version}-trigger-tiers-{os}'
+                        predefined-parameters: |
+                          SERVER_HOSTNAME=${{SERVER_HOSTNAME}}
+                          SATELLITE_DISTRIBUTION=${{SATELLITE_DISTRIBUTION}}
+                          RHEL6_TOOLS_REPO=${{RHEL6_TOOLS_REPO}}
+                          RHEL7_TOOLS_REPO=${{RHEL7_TOOLS_REPO}}
+                          CAPSULE_REPO=${{CAPSULE_REPO}}
+                          SUBNET=${{SUBNET}}
+                          NETMASK=${{NETMASK}}
+                          GATEWAY=${{GATEWAY}}
+                          BRIDGE=${{BRIDGE}}
+                          BUILD_LABEL=${{BUILD_LABEL}}
+                          DISCOVERY_ISO=${{DISCOVERY_ISO}}
+                          ROBOTTELO_WORKERS=${{ROBOTTELO_WORKERS}}
+                          IMAGE=${{IMAGE}}
+                          SAUCE_BROWSER=${{SAUCE_BROWSER}}
+                          SAUCE_PLATFORM=${{SAUCE_PLATFORM}}
+                          RUBY_CODE_COVERAGE=${{RUBY_CODE_COVERAGE}}
+        - conditional-step:
+                    condition-kind: regex-match
+                    regex: (6\.[5])
+                    label: ${{ENV,var="SATELLITE_VERSION"}}
+                    steps:
+                    - trigger-builds:
+                      - project: 'automation-{satellite_version}-trigger-tiers-{os}'
+                        predefined-parameters: |
+                          SERVER_HOSTNAME=${{SERVER_HOSTNAME}}
+                          SATELLITE_DISTRIBUTION=${{SATELLITE_DISTRIBUTION}}
+                          RHEL6_TOOLS_REPO=${{RHEL6_TOOLS_REPO}}
+                          RHEL7_TOOLS_REPO=${{RHEL7_TOOLS_REPO}}
+                          CAPSULE_REPO=${{CAPSULE_REPO}}
+                          SUBNET=${{SUBNET}}
+                          NETMASK=${{NETMASK}}
+                          GATEWAY=${{GATEWAY}}
+                          BRIDGE=${{BRIDGE}}
+                          BUILD_LABEL=${{BUILD_LABEL}}
+                          DISCOVERY_ISO=${{DISCOVERY_ISO}}
+                          ROBOTTELO_WORKERS=${{ROBOTTELO_WORKERS}}
+                          IMAGE=${{IMAGE}}
+                          SAUCE_BROWSER=${{SAUCE_BROWSER}}
+                          SAUCE_PLATFORM=${{SAUCE_PLATFORM}}
+                          RUBY_CODE_COVERAGE=${{RUBY_CODE_COVERAGE}}
     publishers:
         - satellite6-automation-mails
         - satellite6-automation-archiver
@@ -1234,6 +1264,7 @@
                         IMAGE=${{RHEL6_IMAGE}}
                         SAUCE_BROWSER=${{SAUCE_BROWSER}}
                         SAUCE_PLATFORM=${{SAUCE_PLATFORM}}
+                        START_TIER=${{START_TIER}}
         - trigger-builds:
             - project: provisioning-{satellite_version}-rhel7
               predefined-parameters: |
@@ -1251,6 +1282,7 @@
                 IMAGE=${{RHEL7_IMAGE}}
                 SAUCE_BROWSER=${{SAUCE_BROWSER}}
                 SAUCE_PLATFORM=${{SAUCE_PLATFORM}}
+                START_TIER=${{START_TIER}}
         - conditional-step:
             condition-kind: regex-match
             regex: (6\.[2345])


### PR DESCRIPTION
Closes #1298
Tested, look under provisioning-6.3-rhel7 184 and 185 JOB
Usage:
START_TIER = true - provision job will trigger tier jobs
START_TIER = (false or anything else) -  provision job will not trigger tier jobs (default)
Above parameter will have no affect on 6.5 jobs, that will be Major downstream pipeline.