### PR TITLE
Fixes populate job

### DIFF
--- a/jobs/satellite6-client-populate.yaml
+++ b/jobs/satellite6-client-populate.yaml
@@ -154,3 +154,11 @@
                     - 'scripts/satellite6-client-automation.sh'
                     - 'scripts/satellite6-configure.sh'
                     - 'scripts/satellite6-configure-variables.sh'
+    publishers:
+        - email-ext:
+            recipients: $BUILD_USER_EMAIL
+            success: true
+            failure: true
+            subject: 'Your Satellite $SATELLITE_VERSION Client Automation Job finished'
+            body: |
+                Build URL: $BUILD_URL

--- a/scripts/satellite6-configure.sh
+++ b/scripts/satellite6-configure.sh
@@ -31,11 +31,14 @@ else
     chmod 755 satellite6-populate.sh
 fi
 
-
 if [[ -n "${NMINUSONE}" ]]; then
-    if [[ "${SATELLITE_VERSION}" = "6.4" ]]; then
-        export SATELLITE_VERSION=6.3
-    elif [[ "${SATELLITE_VERSION}" = "6.3" ]]; then
-        export SATELLITE_VERSION=6.2
+    if [[ "${NMINUSONE}" = "true" ]]; then
+        if [[ "${SATELLITE_VERSION}" = "6.4" ]]; then
+            export SATELLITE_VERSION=6.3
+        elif [[ "${SATELLITE_VERSION}" = "6.5" ]]; then
+            export SATELLITE_VERSION=6.4
+        elif [[ "${SATELLITE_VERSION}" = "6.3" ]]; then
+            export SATELLITE_VERSION=6.2
+        fi
     fi
 fi


### PR DESCRIPTION
- Added email publisher for satellite 6 client populate job

- Fixes n-1 support and added 6.5

- Added maintain product and repo variable for GA

- Select only first id if multiple result found for "Red Hat Enterprise Linux Server, Standard (Physical or Virtual Nodes)" subscription.

- Fixes  activation-key content-override as  for 6.2, '--value': value must be one of '0', '1', 'default'. 0 and 1 works for all versions.

- Fixes VMware compute resource creation for 6.2.
 