### PR TITLE
skip extra_files phase during compose generation

### DIFF
--- a/ansible/playbooks/build_compose.yml
+++ b/ansible/playbooks/build_compose.yml
@@ -19,7 +19,7 @@
         path: "{{ compose_link.stdout }}"
 
     - name: 'Generate compose'
-      command: "pungi-koji --test --config={{ compose_conf_dir }}/pungi/satellite-6/{{ compose_version }}/{{ compose_name }}-rhel-{{ rhel_version }}-{{ compose_tag }}.conf --target-dir={{ compose_output_dir }} --skip-phase=createiso --skip-phase=live_images --skip-phase=test"
+      command: "pungi-koji --test --config={{ compose_conf_dir }}/pungi/satellite-6/{{ compose_version }}/{{ compose_name }}-rhel-{{ rhel_version }}-{{ compose_tag }}.conf --target-dir={{ compose_output_dir }} --skip-phase=createiso --skip-phase=live_images --skip-phase=test --skip-phase=extra_files"
 
     - name: 'Find repos to cleanup'
       find:


### PR DESCRIPTION
this skips copying RHSCL to the compose box and thus
* saves about 2 minutes of build time each run
* about 2.6GB of space on each compose run