### PR TITLE
move plugin configuration before DB configuration

### DIFF
--- a/workflows/test/foreman-lib.groovy
+++ b/workflows/test/foreman-lib.groovy
@@ -85,8 +85,7 @@ def setup_foreman(ruby = '2.2') {
     }
 }
 
-def setup_plugin(plugin_name, ruby = '2.2') {
-    try {
+def setup_plugin(plugin_name) {
         // Ensure we don't mention the gem twice in the Gemfile in case it's already mentioned there
         sh "find Gemfile bundler.d -type f -exec sed -i \"/gem ['\\\"]${plugin_name}['\\\"]/d\" {} \\;"
         // Now let's introduce the plugin
@@ -95,18 +94,6 @@ def setup_plugin(plugin_name, ruby = '2.2') {
         if(fileExists("../plugin/gemfile.d/${plugin_name}.rb")) {
             sh "cat ../plugin/gemfile.d/${plugin_name}.rb >> bundler.d/Gemfile.local.rb"
         }
-
-        withRVM(['bundle update'], ruby)
-
-        withRVM(['bundle exec rake db:migrate'], ruby)
-
-    } catch (all) {
-
-        updateGitlabCommitStatus state: 'failed'
-        cleanup(get_ruby_version(branch_map))
-        throw(all)
-
-    }
 }
 
 def cleanup(ruby = '2.2') {

--- a/workflows/test/foreman-plugin.groovy
+++ b/workflows/test/foreman-plugin.groovy
@@ -32,10 +32,18 @@ pipeline {
             }
         }
 
-        stage('Configure Environment') {
+        stage('Configure Foreman') {
             steps {
                 dir('foreman') {
                     configure_foreman_environment()
+                }
+            }
+        }
+
+        stage('Configure Plugin') {
+            steps {
+                dir('foreman') {
+                    setup_plugin(plugin_name)
                 }
             }
         }
@@ -44,14 +52,6 @@ pipeline {
             steps {
                 dir('foreman') {
                     setup_foreman(ruby)
-                }
-            }
-        }
-
-        stage('Setup plugin') {
-            steps {
-                dir('foreman') {
-                    setup_plugin(plugin_name, ruby)
                 }
             }
         }

--- a/workflows/test/katello.groovy
+++ b/workflows/test/katello.groovy
@@ -28,10 +28,18 @@ pipeline {
             }
         }
 
-        stage('Configure Environment') {
+        stage('Configure Foreman') {
             steps {
                 dir('foreman') {
                     configure_foreman_environment()
+                }
+            }
+        }
+
+        stage('Configure Plugin') {
+            steps {
+                dir('foreman') {
+                    setup_plugin(plugin_name)
                 }
             }
         }
@@ -40,14 +48,6 @@ pipeline {
             steps {
                 dir('foreman') {
                     setup_foreman(ruby)
-                }
-            }
-        }
-
-        stage('Setup plugin') {
-            steps {
-                dir('foreman') {
-                    setup_plugin(plugin_name, ruby)
                 }
             }
         }


### PR DESCRIPTION
this allows us to call "bundle install" and "db:migrate" once, thus
saving time and potential problems with "bundle update"