### PR TITLE
Upgrade moving to python3 in Jenkins

### DIFF
--- a/jobs/builders/satellite6_upgrade_builders.yaml
+++ b/jobs/builders/satellite6_upgrade_builders.yaml
@@ -1,13 +1,33 @@
 - builder:
     name: satellite6-upgrade-builders
     builders:
-        - shining-panda:
-            build-environment: virtualenv
-            python-version: System-CPython-2.7
-            clear: true
-            nature: shell
-            command:
-                !include-raw:
-                    - 'pip-install-pycurl.sh'
-                    - 'satellite6-upgrade-source.sh'
-                    - 'satellite6-upgrade-trigger.sh'
+        - conditional-step:
+            condition-kind: regex-match
+            regex: (6\.[12])
+            label: ${ENV,var="SATELLITE_VERSION"}
+            steps:
+                - shining-panda:
+                    build-environment: virtualenv
+                    python-version: System-CPython-2.7
+                    clear: true
+                    nature: shell
+                    command:
+                        !include-raw:
+                            - 'pip-install-pycurl.sh'
+                            - 'satellite6-upgrade-source.sh'
+                            - 'satellite6-upgrade-trigger.sh'
+        - conditional-step:
+            condition-kind: regex-match
+            regex: (6\.[345])
+            label: ${ENV,var="SATELLITE_VERSION"}
+            steps:
+                - shining-panda:
+                    build-environment: virtualenv
+                    python-version: System-CPython-3.6
+                    clear: true
+                    nature: shell
+                    command:
+                        !include-raw:
+                            - 'pip-install-pycurl.sh'
+                            - 'satellite6-upgrade-source.sh'
+                            - 'satellite6-upgrade-trigger.sh'

--- a/jobs/builders/satellite6_upgrade_existence_builders.yaml
+++ b/jobs/builders/satellite6_upgrade_existence_builders.yaml
@@ -1,13 +1,33 @@
 - builder:
     name: satellite6-upgrade-existence-builders
     builders:
-        - shining-panda:
-            build-environment: virtualenv
-            python-version: System-CPython-2.7
-            clear: true
-            nature: shell
-            command:
-                !include-raw:
-                    - 'pip-install-pycurl.sh'
-                    - 'satellite6-upgrade-source.sh'
-                    - 'satellite6-upgrade-existence.sh'
+        - conditional-step:
+            condition-kind: regex-match
+            regex: (6\.[12])
+            label: ${ENV,var="SATELLITE_VERSION"}
+            steps:
+                - shining-panda:
+                    build-environment: virtualenv
+                    python-version: System-CPython-2.7
+                    clear: true
+                    nature: shell
+                    command:
+                        !include-raw:
+                            - 'pip-install-pycurl.sh'
+                            - 'satellite6-upgrade-source.sh'
+                            - 'satellite6-upgrade-existence.sh'
+        - conditional-step:
+            condition-kind: regex-match
+            regex: (6\.[345])
+            label: ${ENV,var="SATELLITE_VERSION"}
+            steps:
+                - shining-panda:
+                    build-environment: virtualenv
+                    python-version: System-CPython-3.6
+                    clear: true
+                    nature: shell
+                    command:
+                        !include-raw:
+                            - 'pip-install-pycurl.sh'
+                            - 'satellite6-upgrade-source.sh'
+                            - 'satellite6-upgrade-existence.sh'

--- a/jobs/builders/satellite6_upgrade_scenarios_builders.yaml
+++ b/jobs/builders/satellite6_upgrade_scenarios_builders.yaml
@@ -1,13 +1,33 @@
 - builder:
     name: satellite6-upgrade-scenarios-builders
     builders:
-        - shining-panda:
-            build-environment: virtualenv
-            python-version: System-CPython-2.7
-            clear: true
-            nature: shell
-            command:
-                !include-raw:
-                    - 'pip-install-pycurl.sh'
-                    - 'satellite6-upgrade-source.sh'
-                    - 'satellite6-upgrade-run-scenarios.sh'
+        - conditional-step:
+            condition-kind: regex-match
+            regex: (6\.[12])
+            label: ${ENV,var="SATELLITE_VERSION"}
+            steps:
+                - shining-panda:
+                    build-environment: virtualenv
+                    python-version: System-CPython-2.7
+                    clear: true
+                    nature: shell
+                    command:
+                        !include-raw:
+                            - 'pip-install-pycurl.sh'
+                            - 'satellite6-upgrade-source.sh'
+                            - 'satellite6-upgrade-run-scenarios.sh'
+        - conditional-step:
+            condition-kind: regex-match
+            regex: (6\.[345])
+            label: ${ENV,var="SATELLITE_VERSION"}
+            steps:
+                - shining-panda:
+                    build-environment: virtualenv
+                    python-version: System-CPython-3.6
+                    clear: true
+                    nature: shell
+                    command:
+                        !include-raw:
+                            - 'pip-install-pycurl.sh'
+                            - 'satellite6-upgrade-source.sh'
+                            - 'satellite6-upgrade-run-scenarios.sh'

--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -806,7 +806,7 @@
         - git:
             url: https://github.com/SatelliteQE/satellite6-upgrade.git
             branches:
-                - origin/master
+                - '{scm-branch}'
             skip-tag: true
     wrappers:
         - default-wrappers
@@ -925,7 +925,7 @@
         - git:
             url: https://github.com/SatelliteQE/satellite6-upgrade.git
             branches:
-                - origin/master
+                - '{scm-branch}'
             skip-tag: true
     wrappers:
         - default-wrappers
@@ -980,7 +980,7 @@
         - git:
             url: https://github.com/SatelliteQE/satellite6-upgrade.git
             branches:
-                - origin/master
+                - '{scm-branch}'
             skip-tag: true
     wrappers:
         - default-wrappers


### PR DESCRIPTION
This PR contains updates,

 to builders:

 satellite6-upgrade-builders
 satellite6-upgrade-existence-builders
 satellite6-upgrade-scenarios-builders

 for job:

upgrade-to
preupgrade-scenario
upgrade-phase
existence
postupgrade-scenario

to set the python environment according to satellite version and satellite6-upgrade branch

Also, the upgrade job-templates now uses upgrade branches as per satellite version i.e scm_branch.