### PR TITLE
update tests-destructive job

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -114,7 +114,11 @@ else
 fi
 
 if [ "${ENDPOINT}" == "destructive" ]; then
-    make test-foreman-sys
+    $(which py.test) -v --junit-xml="${ENDPOINT}-results.xml" \
+        -o junit_suite_name="${ENDPOINT}" \
+        -m 'not stubbed and destructive'
+        tests/foreman/
+
 elif [ "${ENDPOINT}" != "rhai" ]; then
     set +e
     # Run sequential tests


### PR DESCRIPTION
updating to the same style as the other tiered tests and adding the pytest junit option to set the suite name.
the old name defaulted to "pytest" which generated wrong tags in report portal.