### PR TITLE
enable compose for el8 tools

### DIFF
--- a/workflows/6.5/releasePipelineAttributes.groovy
+++ b/workflows/6.5/releasePipelineAttributes.groovy
@@ -1,5 +1,5 @@
 def compose_versions = ['7']
-def tools_compose_versions = ['7', '6', '5']
+def tools_compose_versions = ['8', '7', '6', '5']
 
 def os_versions = ['7']
 


### PR DESCRIPTION
this should only be merged *after* we have at least one el8 package built, otherwise the compose run will fail