### PR TITLE
Revert "use --dist=loadscope for parralel tests"

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -127,7 +127,6 @@ elif [ "${ENDPOINT}" != "rhai" ]; then
     $(which py.test) -v --junit-xml="${ENDPOINT}-parallel-results.xml" -n "${ROBOTTELO_WORKERS}" \
         -o junit_suite_name="${ENDPOINT}-parallel" \
         -m "${ENDPOINT} and not run_in_one_thread and not stubbed" \
-        --dist=loadscope \
         ${TEST_TYPE} ${TIMEOUT}
     set -e
 else


### PR DESCRIPTION
Reverts SatelliteQE/robottelo-ci#1425