### PR TITLE
Archive TemplateStores for template existence tests as artifcts

### DIFF
--- a/scripts/satellite6-upgrade-existence.sh
+++ b/scripts/satellite6-upgrade-existence.sh
@@ -2,6 +2,10 @@
 pip install -r requirements.txt
 pip install -r requirements-optional.txt
 
+# Untar templates data
+tar -xf preupgrade_templates.tar.xz
+tar -xf postupgrade_templates.tar.xz
+
 set +e
 export ENDPOINT='cli'
 $(which py.test) -v --continue-on-collection-errors --junit-xml=test_existance_cli-results.xml -o junit_suite_name=test_existance_cli upgrade_tests/test_existance_relations/cli/

--- a/scripts/satellite6-upgrade-trigger.sh
+++ b/scripts/satellite6-upgrade-trigger.sh
@@ -44,6 +44,7 @@ elif [ ${ENDPOINT} == 'upgrade' ]; then
     fab -u root set_datastore:"preupgrade","cli"
     fab -u root set_datastore:"preupgrade","api"
     fab -u root set_templatestore:"preupgrade"
+    tar -cf preupgrade_templates.tar.xz preupgrade_templates
 
     # Longrun to run upgrade on Satellite, capsule and clients
     fab -u root product_upgrade:'longrun'
@@ -53,4 +54,5 @@ elif [ ${ENDPOINT} == 'upgrade' ]; then
     fab -u root set_datastore:"postupgrade","cli"
     fab -u root set_datastore:"postupgrade","api"
     fab -u root set_templatestore:"postupgrade"
+    tar -cf postupgrade_templates.tar.xz postupgrade_templates
 fi


### PR DESCRIPTION
Currently, the template existence tests are not running as the Jenkins job unable to collect the templatestore directory as an artifact.

Hence, tar-ing the directory to be collected by job and later untar to use the templates from the store.