### PR TITLE
Satellite6 upgrade cleanup job: Updated cron and added  

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -1345,6 +1345,8 @@
                       predefined-parameters: |
                         BUILD_LABEL=${{BUILD_LABEL}}
                         ROBOTTELO_WORKERS=${{ROBOTTELO_WORKERS}}
+                - trigger-builds:
+                    - project: satellite6-upgrade-cleanup 
 
 #==============================================================================
 # Project

--- a/jobs/satellite6-upgrade-cleanup.yaml
+++ b/jobs/satellite6-upgrade-cleanup.yaml
@@ -13,7 +13,7 @@
             skip-tag: true
             wipe-workspace: true
     triggers:
-        - timed: 'H 17 * * 0,2,4'
+        - timed: 'H 19 * * 4'
     wrappers:
         - config-file-provider:
             files:


### PR DESCRIPTION
> Added Satellite6 upgrade cleanup job under trigger-builds to cleanup the containers.
> Updated the cron to keep container till Thursday evening for test failures analysis.