### PR TITLE
Hold test Run job untill the xml reports ready for upgrade end-to-end

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -1186,7 +1186,9 @@
     publishers:
         - satellite6-automation-mails
         - satellite6-automation-publishers
-        - satellite6-automation-archiver
+        - archive:
+            artifacts: 'robottelo*.log,*-results.xml,robottelo.properties'
+            allow-empty: true
 
 - job-template:
     name: trigger-satellite-{satellite_version}


### PR DESCRIPTION
Fixes Polarion Test Run job failing with failed to find xml artifact from upgraded end-to-end tests job.