### PR TITLE
Run fix_hostname and setup_fake_manifest_certificate tasks integrated

### DIFF
--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -60,11 +60,6 @@
                 - 'non-authenticated'
                 - 'no-proxy'
         - bool:
-            name: FIX_HOSTNAME
-            default: true
-            description: |
-                Run a task to updates /etc/hosts with FQDN and IP
-        - bool:
             name: PARTITION_DISK
             default: true
             description: |
@@ -80,12 +75,6 @@
             default: master
             description: |
                 You can override this to any branch.
-        - bool:
-            name: SETUP_FAKE_MANIFEST_CERTIFICATE
-            default: false
-            description: |
-                Run a task to install a fake manifest certificate. Run this if
-                you are planning to run Robottelo tests.
         - bool:
             name: STAGE_TEST
             default: false

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -5,6 +5,7 @@ export OS_VERSION=$(fab -D -H root@${SERVER_HOSTNAME} distro_info | grep "rhel [
 DISTRO="rhel${OS_VERSION}"
 
 source ${CONFIG_FILES}
+source config/fake_manifest.conf
 source config/auth_servers.conf
 source config/installation_environment.conf
 source config/proxy_config_environment.conf
@@ -21,10 +22,6 @@ fi
 
 export EXTERNAL_AUTH
 export IDM_REALM
-
-if [ ${FIX_HOSTNAME} = "true" ]; then
-    fab -D -H root@${SERVER_HOSTNAME} fix_hostname
-fi
 
 if [ ${PARTITION_DISK} = "true" ]; then
     fab -D -H root@${SERVER_HOSTNAME} partition_disk
@@ -71,7 +68,3 @@ fi
 
 fab -D -H root@${SERVER_HOSTNAME} product_install:${DISTRIBUTION},sat_version=${SATELLITE_VERSION},test_in_stage=${STAGE_TEST},puppet4=${PUPPET4}
 
-if [ ${SETUP_FAKE_MANIFEST_CERTIFICATE} = "true" ]; then
-    source config/fake_manifest.conf
-    fab -D -H root@${SERVER_HOSTNAME} setup_fake_manifest_certificate
-fi


### PR DESCRIPTION
For standalone installer job run the tasks integrated as we do for provisioning job to keep these two jobs more unified (these two jobs could be handled by just one common shell script anyway)

- setup_fake_manifest_certificate removal is OK 
 (see https://github.com/SatelliteQE/automation-tools/blob/master/automation_tools/__init__.py#L2432-L2439)
- fix_hostname removal depends on changes in https://github.com/SatelliteQE/automation-tools/pull/776 (merged)