### PR TITLE
add report_portal feed pipeline

### DIFF
--- a/jenkins_jobs.ini.sample
+++ b/jenkins_jobs.ini.sample
@@ -6,6 +6,6 @@ allow_duplicates=False
 exclude=foreman-infra/yaml/defaults:foreman-infra/yaml/jobs
 
 #[jenkins]
-#user=<jenkin-user>
+#user=<jenkins-user>
 #password=<jenkins-api-key>
 #url=<jenkins-url>

--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -175,6 +175,14 @@
                   BUILD_LABEL=${{BUILD_LABEL}}
               - name: 'report-consolidated-coverage-{satellite_version}-{os}'
                 current-parameters: true
+    publishers:
+        - trigger-parameterized-builds:
+          - project:
+              - satellite6-report-portal
+            predefined-parameters: |
+              AUTOMATION_BUILD_URL=${{BUILD_URL}}
+              BUILD_TAGS="${{SATELLITE_VERSION}} {os} ${{BUILD_LABEL}}"
+            node-parameters: true
 
 
 - job-template:
@@ -1166,6 +1174,13 @@
         - satellite6-automation-mails
         - satellite6-automation-publishers
         - satellite6-automation-archiver
+        - trigger-parameterized-builds:
+          - project:
+              - satellite6-report-portal
+            predefined-parameters: |
+              AUTOMATION_BUILD_URL=${{BUILD_URL}}
+              BUILD_TAGS="${{SATELLITE_VERSION}} {os} ${{BUILD_LABEL}}"
+            node-parameters: true
 
 - job-template:
     name: 'automation-upgraded-{satellite_version}-end-to-end-{os}'

--- a/jobs/satellite6-report-portal.yaml
+++ b/jobs/satellite6-report-portal.yaml
@@ -1,0 +1,43 @@
+- job:
+    name: 'satellite6-report-portal'
+    concurrent: true
+    display-name: 'Satellite 6 Report Portal'
+    description: |
+        Job that takes build url of satellite6-trigger-all-tiers job and parses, uploads and set ownerships of test case results in Report Portal
+        It also accepts BUILD_LABEL and BUILD_TAGS (for specifying a space-separated list of tags for the launch) parameters.
+    parameters:
+        - string:
+            name: AUTOMATION_BUILD_URL
+        - string:
+            name: BUILD_TAGS
+        - string:
+            name: RP_PROJECT
+            default: 'satellite6'
+        - string:
+            name: RP_TOOLS_FORK
+            default: 'satelliteqe'
+        - string:
+            name: RP_TOOLS_BRANCH
+            default: 'master'
+        - string:
+            name: WORKERS
+            default: '8'
+    project-type: pipeline
+    pipeline-scm:
+        scm:
+          - git:
+                url: https://github.com/SatelliteQE/robottelo-ci.git
+                branches:
+                  - origin/master
+                clean: true
+        script-path: workflows/qe/satellite6-report-portal.groovy
+        lightweight-checkout: true
+    wrappers:
+        - build-name:
+            name: '#${BUILD_NUMBER}'
+        - build-user-vars
+        - config-file-provider:
+            files:
+                - file-id: bc5f0cbc-616f-46de-bdfe-2e024e84fcbf
+                  variable: CONFIG_FILES
+        - default-wrappers

--- a/workflows/qe/satellite6-report-portal.groovy
+++ b/workflows/qe/satellite6-report-portal.groovy
@@ -1,0 +1,110 @@
+@Library("github.com/SatelliteQE/robottelo-ci") _
+
+pipeline {
+    agent {
+        label 'sat6-rhel'
+    }
+    stages {
+        stage('Virtualenv') {
+  	        steps {
+                make_venv python: defaults.python
+            }
+        }
+        stage('Clone rp_tools repo') {
+            steps {
+	        configFileProvider(
+		    [configFile(fileId: 'e8b0ed3c-2ca3-4a0c-a922-60264c11bbc9', variable: 'RP_TOOLS')]) {
+		        sh_venv """
+			    source \${RP_TOOLS}
+			"""
+		    }
+            }
+        }
+        stage('Configure rp_tools') {
+            steps {
+                sh_venv """
+	            cd rp_tools
+                    export PYCURL_SSL_LIBRARY=\$(curl -V | sed -n 's/.*\\(NSS\\|OpenSSL\\).*/\\L\\1/p')
+                    pip install -r requirements.txt
+                    """
+                configFileProvider(
+                    [configFile(fileId: 'bc5f0cbc-616f-46de-bdfe-2e024e84fcbf', variable: 'CONFIG_FILES')]) {
+                         sh_venv '''
+                             source ${CONFIG_FILES}
+                             cp config/rp_conf.yaml rp_tools/scripts/reportportal_cli/rp_conf.yaml
+                             sed -i "s/^rp_project.\\+$/rp_project: ${RP_PROJECT}/" rp_tools/scripts/reportportal_cli/rp_conf.yaml
+                             mkdir rp_tools/scripts/jenkins_junit/junits
+                            '''
+                         }
+
+            }
+        }
+        stage('Collect Junit XMLs') {
+            steps {
+                sh_venv '''
+                    cd rp_tools/scripts/jenkins_junit/
+                    if echo "${AUTOMATION_BUILD_URL}" | grep -q 'automation-upgraded-[0-9.]\\+-all-tiers-rhel[0-9]\\+'; then
+                        cd junits/ && rm -f *.xml
+                        wget --no-verbose --no-check-certificate "${AUTOMATION_BUILD_URL}/artifact/all-tiers-upgrade-parallel-results.xml"
+                        wget --no-verbose --no-check-certificate "${AUTOMATION_BUILD_URL}/artifact/all-tiers-upgrade-sequential-results.xml"
+                    else
+                        python3 fetch_junit.py ${AUTOMATION_BUILD_URL} -v
+                    fi
+                '''
+            }
+        }
+        stage('Push results to Report Portal') {
+            steps {
+                sh_venv '''
+                    cd rp_tools/scripts/reportportal_cli
+                    if echo "${AUTOMATION_BUILD_URL}" | grep -q 'automation-upgraded-[0-9.]\\+-all-tiers-rhel[0-9]\\+'; then
+                        rp_cli_extra_opts="--launch_name Upgrades"
+                    fi
+                    ./rp_cli.py --xunit_feed '../jenkins_junit/junits/*.xml' --strategy Sat --config rp_conf.yaml --launch_tags "${BUILD_TAGS}" ${rp_cli_extra_opts}
+                '''
+            }
+        }
+        stage('Ownership tags') {
+            steps {
+                sh_venv '''
+                    cd rp_tools/scripts/reportportal_cli/
+                    ./owners_cli.py --insecure
+                '''
+            }
+        }
+        stage('Claim known issues') {
+            steps {
+                sh_venv '''
+                    cd rp_tools/scripts/reportportal_cli/
+                    master=$( echo "$BUILD_TAGS" | sed 's/ \\+/\n/g' | grep '^6\\.[0-9]\\+$' | head -n 1 )
+                    rules="kb$( echo "$master" | sed 's/\\.//' ).json"
+                    if [ -e "$rules" ]; then
+                        echo "Looks like we are processing '$master' launch, so will use '$rules' rules file"
+                        ./claiming_cli.py --insecure --rules "$rules" -n 8
+                    else
+                        echo "ERROR: No rules file for launch with tags: '$BUILD_TAGS'" >&2
+                    fi
+                '''
+            }
+        }
+        stage('E-Mail owners') {
+            steps {
+                sh_venv '''
+                    cd rp_tools/scripts/reportportal_cli/
+                    #to prevent this step from actually sending the mail (dry run) just uncomment this:
+                    #sed -i 's/server\\.sendmail/print/' alert_cli.py
+                    ./alert_cli.py
+                '''
+            }
+        }
+        stage('Generate initial status report') {
+            steps {
+                sh_venv '''
+                    cd rp_tools/scripts/reportportal_cli/
+                    ./todo_cli.py --insecure
+                '''
+            }
+        }
+
+    }
+  }


### PR DESCRIPTION
Pipeline job that processes given automation multijob (or upgrade-all-tiers build url), uploads the results to report portal instance, tags the already known issues, tag the owners and send out emails.

![jenkins](https://i.imgur.com/hE6e0a7.png)

The commit also adds the trigger to the `satellite6-automation` and `upgrade-all-tiers` jobs