### PR TITLE
make the satellite6-report-portal run conditionally only on completed builds

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -183,6 +183,7 @@
               AUTOMATION_BUILD_URL=${{BUILD_URL}}
               BUILD_TAGS="${{SATELLITE_VERSION}} {os} ${{BUILD_LABEL}}"
             node-parameters: true
+            condition: 'UNSTABLE_OR_BETTER'
 
 
 - job-template:
@@ -1181,6 +1182,7 @@
               AUTOMATION_BUILD_URL=${{BUILD_URL}}
               BUILD_TAGS="${{SATELLITE_VERSION}} {os} ${{BUILD_LABEL}}"
             node-parameters: true
+            condition: 'UNSTABLE_OR_BETTER'
 
 - job-template:
     name: 'automation-upgraded-{satellite_version}-end-to-end-{os}'


### PR DESCRIPTION
Currently the job is triggered unconditionally, that means, even if the parent build fails -> this doesn't make sense and makes the report-portal pipeline fail as there is nothing to report.

The `condition` parameter of the `trigger-parameterized-build` publisher should address this:
https://docs.openstack.org/infra/jenkins-job-builder/publishers.html#publishers.trigger-parameterized-builds