### PR TITLE
making sure sat_tools_repos to evaluate correct repos

### DIFF
--- a/scripts/satellite6-upgrade-run-scenarios.sh
+++ b/scripts/satellite6-upgrade-run-scenarios.sh
@@ -26,6 +26,7 @@ function setupPrerequisites () {
     sed -i "s/# gateway=.*/gateway=${GATEWAY}/" robottelo.properties
     sed -i "s/# netmask=.*/netmask=${NETMASK}/" robottelo.properties
 
+    sed -i "s|sattools_repo=.*|sattools_repo=rhel8=${RHEL8_TOOLS_REPO},rhel7=${RHEL7_TOOLS_REPO},rhel6=${RHEL6_TOOLS_REPO}|" robottelo.properties
     # Robottelo logging configuration
     sed -i "s/'\(robottelo\).log'/'\1-${ENDPOINT}.log'/" logging.conf
     # Bugzilla Login Details


### PR DESCRIPTION
### PR Objective 
sat_tools repos are not getting evaluated correctly in pre-upgrade failing some scenarios. please check Jira  4195 for more information.
Now it should update the robottelo properties file with correct sat_tools_repo.

Not sure how I can test this up, just to ensure the change is valid enough.  
 