### PR TITLE
Python2 cleanup (was required for 6.2 standalone automation)

### DIFF
--- a/jobs/builders/satellite6_standalone_automation_builders.yaml
+++ b/jobs/builders/satellite6_standalone_automation_builders.yaml
@@ -1,31 +1,13 @@
 - builder:
     name: satellite6-standalone-automation-builders
     builders:
-        - conditional-step:
-            condition-kind: regex-match
-            regex: (6\.[12])
-            label: ${ENV,var="SATELLITE_VERSION"}
-            steps:
-                - shining-panda:
-                    build-environment: virtualenv
-                    python-version: System-CPython-2.7
-                    clear: true
-                    nature: shell
-                    command:
-                        !include-raw:
-                            - 'satellite6-standalone-automation.sh'
-                            - 'satellite6-foreman-debug.sh'
-        - conditional-step:
-            condition-kind: regex-match
-            regex: (6\.[3456]|upstream-nightly)
-            label: ${ENV,var="SATELLITE_VERSION"}
-            steps:
-                - shining-panda:
-                    build-environment: virtualenv
-                    python-version: System-CPython-3.6
-                    clear: true
-                    nature: shell
-                    command:
-                        !include-raw:
-                            - 'satellite6-standalone-automation.sh'
-                            - 'satellite6-foreman-debug.sh'
+        - shining-panda:
+            build-environment: virtualenv
+            python-version: System-CPython-3.6
+            clear: true
+            nature: shell
+            command:
+                !include-raw:
+                    - 'satellite6-standalone-automation.sh'
+                    - 'satellite6-foreman-debug.sh'
+    


### PR DESCRIPTION
this change I missed to pack in along with general versions cleanup (https://github.com/SatelliteQE/robottelo-ci/pull/1526)