### PR TITLE
remove doublequotes from RP_TAGS parameter

### DIFF
--- a/jobs/satellite6-automation.yaml
+++ b/jobs/satellite6-automation.yaml
@@ -181,7 +181,7 @@
               - satellite6-report-portal
             predefined-parameters: |
               AUTOMATION_BUILD_URL=${{BUILD_URL}}
-              BUILD_TAGS="${{SATELLITE_VERSION}} {os} ${{BUILD_LABEL}}"
+              BUILD_TAGS=${{SATELLITE_VERSION}} {os} ${{BUILD_LABEL}}
             node-parameters: true
             condition: 'UNSTABLE_OR_BETTER'
 
@@ -1181,7 +1181,7 @@
               - satellite6-report-portal
             predefined-parameters: |
               AUTOMATION_BUILD_URL=${{BUILD_URL}}
-              BUILD_TAGS="${{SATELLITE_VERSION}} {os} ${{BUILD_LABEL}}"
+              BUILD_TAGS=${{SATELLITE_VERSION}} {os} ${{BUILD_LABEL}}
             node-parameters: true
             condition: 'UNSTABLE_OR_BETTER'
 


### PR DESCRIPTION
The extra quotes got evaluated as a part of the tags in report portal, we need to remove them.
- tested the commit on my local jenkins instance to make sure it does not break anything