### PR TITLE
extend sh_venv to unmaks the rest of the original sh method parameters

### DIFF
--- a/vars/sh_venv.groovy
+++ b/vars/sh_venv.groovy
@@ -1,12 +1,17 @@
 def call(Object param = [:]) {
 
-    if (param in String) param = [body: param]
+    if (param in String) param = [script: param]
 
-    def body = param.get('body', "")
+    def script = param.get('script', "")
     def venv = param.get('venv', ".env")
+    def label = param.get('label', "")
+    def stdo = param.get('returnStdout', false)
+    def rtnc = param.get('returnStatus', false)
 
-    sh """
+
+    def result = sh label: label, returnStatus: rtnc, returnStdout: stdo, script: """
         source ${venv}/bin/activate
-        ${body}
+        ${script}
     """
+    return result
 }


### PR DESCRIPTION
the `sh_venv` wrapper around the original `sh` method works fine, but it does not pass the additional parameters that `sh` accepts.
```groovy
def result = sh label: labl, returnStatus: rtnc, returnStdout: stdo, script: 
'''script body'''
```
this commit implements that.

