### PR TITLE
Fix test running from ui and ui_airgun

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -94,7 +94,12 @@ if [[ "${SATELLITE_VERSION}" == *"upstream-nightly"* ]]; then
     ${EXTRA_MARKS} = "and upgrade"
 fi
 
-TEST_TYPE="$(echo tests/foreman/{api,cli,ui,longrun,sys,installer})"
+if [[ "${SATELLITE_VERSION}" == "6.5" ]] || [[ "${SATELLITE_VERSION}" == "6.4" ]]; then
+    TEST_TYPE="$(echo tests/foreman/{api,cli,ui_airgun,longrun,sys,installer})"
+else
+    TEST_TYPE="$(echo tests/foreman/{api,cli,ui,longrun,sys,installer})"
+fi
+
 
 if [ "${ENDPOINT}" == "destructive" ]; then
     make test-foreman-sys

--- a/scripts/satellite6-betelgeuse-test-case.sh
+++ b/scripts/satellite6-betelgeuse-test-case.sh
@@ -4,6 +4,8 @@ pip install Betelgeuse==0.15.0
 
 if [[ ${BETELGEUSE_AUTOMATION_PROJECT} = "satellite6-upgrade" ]]; then
     export BETELGEUSE_TC_PATH='upgrade_tests/test_existance_relations'
+elif [[ "${SATELLITE_VERSION}" = "6.4" ]] || [[ "${SATELLITE_VERSION}" = "6.5" ]]; then
+    export BETELGEUSE_TC_PATH='tests/foreman/api tests/foreman/cli tests/foreman/ui_airgun tests/foreman/longrun tests/foreman/sys tests/foreman/installer tests/foreman/rhai'
 else
     export BETELGEUSE_TC_PATH='tests/foreman/api tests/foreman/cli tests/foreman/ui tests/foreman/longrun tests/foreman/sys tests/foreman/installer tests/foreman/rhai'
 fi

--- a/scripts/satellite6-upgrade-tier-source.sh
+++ b/scripts/satellite6-upgrade-tier-source.sh
@@ -98,7 +98,11 @@ if [[ "${SATELLITE_DISTRIBUTION}" != *"GA"* ]]; then
     sed -i "s|capsule_repo=.*|capsule_repo=${CAPSULE_REPO}|" robottelo.properties
 fi
 
-TEST_TYPE="$(echo tests/foreman/{api,cli,ui,longrun,sys,installer})"
+if [[ "${SATELLITE_VERSION}" == "6.5" ]] || [[ "${SATELLITE_VERSION}" == "6.4" ]]; then
+    TEST_TYPE="$(echo tests/foreman/{api,cli,ui_airgun,longrun,sys,installer})"
+else
+    TEST_TYPE="$(echo tests/foreman/{api,cli,ui,longrun,sys,installer})"
+fi
 
 if [ "${ENDPOINT}" != "end-to-end" ]; then
     set +e


### PR DESCRIPTION
In 6.4.z and 6.5.z branch of robotello, we use ui_airgun for the UI tests.