### PR TITLE
implement ${EXTRA_MARKS} for upstream-nightly

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -90,6 +90,9 @@ if [[ "${SATELLITE_DISTRIBUTION}" != *"GA"* ]]; then
     sed -i "s|capsule_repo=.*|capsule_repo=${CAPSULE_REPO}|" robottelo.properties
 fi
 
+if [[ "${SATELLITE_VERSION}" == *"upstream-nightly"* ]]; then
+    ${EXTRA_MARKS} = "and upgrade"
+fi
 
 TEST_TYPE="$(echo tests/foreman/{api,cli,ui,longrun,sys,installer})"
 
@@ -100,13 +103,13 @@ elif [ "${ENDPOINT}" != "rhai" ]; then
     # Run sequential tests
     $(which py.test) -v --junit-xml="${ENDPOINT}-sequential-results.xml" \
         -o junit_suite_name="${ENDPOINT}-sequential" \
-        -m "${ENDPOINT} and run_in_one_thread and not stubbed" \
+        -m "${ENDPOINT} and run_in_one_thread and not stubbed ${EXTRA_MARKS}" \
         ${TEST_TYPE}
 
     # Run parallel tests
     $(which py.test) -v --junit-xml="${ENDPOINT}-parallel-results.xml" -n "${ROBOTTELO_WORKERS}" \
         -o junit_suite_name="${ENDPOINT}-parallel" \
-        -m "${ENDPOINT} and not run_in_one_thread and not stubbed" \
+        -m "${ENDPOINT} and not run_in_one_thread and not stubbed ${EXTRA_MARKS}" \
         ${TEST_TYPE}
     set -e
 else


### PR DESCRIPTION
This should modify the behavior of py.test to run only `@upgrade`-marked tests for `upstream-nightly`