### PR TITLE
fix scoping of packaging vars

### DIFF
--- a/workflows/packaging/satellitePackaging.groovy
+++ b/workflows/packaging/satellitePackaging.groovy
@@ -1,5 +1,5 @@
-def package_version = env.gitlabTargetBranch.minus('SATELLITE-')
-def packaging_repo = 'satellite-packaging'
-def packaging_repo_project = 'satellite6'
+package_version = env.gitlabTargetBranch.minus('SATELLITE-')
+packaging_repo = 'satellite-packaging'
+packaging_repo_project = 'satellite6'
+tool_belt_repo_folder = "satellite_${package_version}"
 def tool_belt_config = './configs/satellite/'
-def tool_belt_repo_folder = "satellite_${package_version}"


### PR DESCRIPTION
`def` scopes them to the current context, so they are not available
inside of functions.

tool_belt_config is a special case, as that is sometimes redefined and
un-scoping it would overwrite the top-scope definition which we don't
want