### PR TITLE
Set the RP_PROJECT variable based on the pipeline

### DIFF
--- a/jobs/satellite6-automation/satellite6-projects.yaml
+++ b/jobs/satellite6-automation/satellite6-projects.yaml
@@ -4,6 +4,7 @@
 - project:
     name: satellite6-automation
     scm-branch: origin/master
+    rp_project: 'satellite6'
     satellite_version:
         - '6.3':
             scm-branch: origin/6.3.z
@@ -12,7 +13,8 @@
         - '6.5':
             scm-branch: origin/6.5.z
         - '6.6'
-        - 'upstream-nightly'
+        - 'upstream-nightly':
+            rp_project: 'katello-nightly'
         - 'downstream-nightly'
     os:
         - 'rhel7'

--- a/jobs/satellite6-automation/satellite6-tiers.yaml
+++ b/jobs/satellite6-automation/satellite6-tiers.yaml
@@ -46,6 +46,7 @@
             predefined-parameters: |
               AUTOMATION_BUILD_URL=${{BUILD_URL}}
               BUILD_TAGS=${{SATELLITE_VERSION}} {os} ${{BUILD_LABEL}}
+              RP_PROJECT={rp_project}
             node-parameters: true
             condition: 'UNSTABLE_OR_BETTER'
 


### PR DESCRIPTION
The default value of `RP_PROJECT` is taken from the `rp_conf.yaml`, which is `Satellite6`. However, we needed a place to pass custom value for jobs as `upstream-nightly`