### PR TITLE
use unsafe writes for forklift boxes

### DIFF
--- a/workflows/lib/libvirt.groovy
+++ b/workflows/lib/libvirt.groovy
@@ -11,6 +11,7 @@ def test_forklift(args) {
 
     runOnLibvirtHost "cd sat-deploy && git -c http.sslVerify=false fetch origin && git reset origin/master --hard"
     runOnLibvirtHost "cd sat-deploy/forklift && git -c http.sslVerify=false fetch origin && git reset origin/master --hard"
+    runOnLibvirtHost "cd sat-deploy/forklift && echo 'libvirt_options: {volume_cache: unsafe}' > vagrant/settings.yaml"
 
     def branches = [:]
 


### PR DESCRIPTION
this has a ~2× speedup in my tests (from ~60 to ~30 minutes) and should
be fine as those are throw-away VMs anyways