### PR TITLE
add conditional to skip e-mailing stage for upstream-nightly builds

### DIFF
--- a/workflows/qe/satellite6-report-portal.groovy
+++ b/workflows/qe/satellite6-report-portal.groovy
@@ -88,6 +88,9 @@ pipeline {
             }
         }
         stage('E-Mail owners') {
+	    when {
+                expression { !env.AUTOMATION_BUILD_URL.contains('upstream-nightly') }
+	    }
             steps {
                 sh_venv '''
                     cd rp_tools/scripts/reportportal_cli/


### PR DESCRIPTION
This should make the pipeline to skip the `E-mail Owners` stage if the build url contains `upstream-nightly`, so owners are not spammed by upstream-nightly jobs (as per decision made by mgmt).