### PR TITLE
make no_saucelabs a default parameter for provisioning job

### DIFF
--- a/jobs/parameters/satellite6_automation_parameters.yaml
+++ b/jobs/parameters/satellite6_automation_parameters.yaml
@@ -54,8 +54,8 @@
         - choice:
             name: SAUCE_BROWSER
             choices:
-                - 'firefox'
                 - 'chrome'
+                - 'firefox'
                 - 'edge'
                 - 'internet explorer'
             description: 'Specify the Sauce Browser to use along with Sauce Platform.'

--- a/jobs/parameters/satellite6_provisioning_parameters.yaml
+++ b/jobs/parameters/satellite6_provisioning_parameters.yaml
@@ -60,16 +60,16 @@
         - choice:
             name: SAUCE_PLATFORM
             choices:
+                - 'no_saucelabs'
                 - 'macOS 10.12'
                 - 'Windows 10'
-                - 'no_saucelabs'
             description: |
                 'Specify the Sauce Platform to run against, along with Sauce Browser.'
         - choice:
             name: SAUCE_BROWSER
             choices:
-                - 'firefox'
                 - 'chrome'
+                - 'firefox'
                 - 'edge'
                 - 'internet explorer'
             description: 'Specify the Sauce Browser to use along with Sauce Platform.'


### PR DESCRIPTION
this should make `no_saucelabs` a default choice also for provisioning jobs

I already updated it in
https://github.com/SatelliteQE/robottelo-ci/pull/1579
but the provisioning job apparently takes the params from different file and all the subprojects in the chain inherit from it.