### PR TITLE
Properly terminate if statements

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -63,9 +63,11 @@ if [ "${SATELLITE_DISTRIBUTION}" = "INTERNAL" ]; then
         export BASE_URL="${SATELLITE6_CUSTOM_BASEURL}"
     else
         export BASE_URL="${SATELLITE6_REPO}"
+    fi
 
     if [ ! -z "${MAINTAIN_CUSTOM_BASEURL}" ]; then
         export MAINTAIN_REPO="${MAINTAIN_CUSTOM_BASEURL}"
+    fi
 fi
 
 fab -D -H root@${SERVER_HOSTNAME} product_install:${DISTRIBUTION},sat_version=${SATELLITE_VERSION},test_in_stage=${STAGE_TEST},puppet4=${PUPPET4}


### PR DESCRIPTION
#1570 left installer script in broken state because if statements were not terminated properly.
See e.g. $JENKINS/job/satellite6-installer/6163/console

On current master:
```
$ bash -n scripts/installer.sh 
scripts/installer.sh: line 73: syntax error: unexpected end of file
```

With this patch:
```
$ bash -n scripts/installer.sh 
$ # no error displayed, return code 0
```