### PR TITLE
do not reuse the same node for the subprojects, since this is disposable agent

### DIFF
--- a/jobs/satellite6-automation/satellite6-tiers.yaml
+++ b/jobs/satellite6-automation/satellite6-tiers.yaml
@@ -38,13 +38,13 @@
               AUTOMATION_BUILD_URL=${{BUILD_URL}}
               BUILD_TAGS=${{SATELLITE_VERSION}} {os} ${{BUILD_LABEL}}
               RP_PROJECT={rp_project}
-            node-parameters: true
+            node-parameters: false
             condition: 'UNSTABLE_OR_BETTER'
           - project:
               - report-automation-results-{satellite_version}-{os}
             predefined-parameters: |
               BUILD_LABEL=${{BUILD_LABEL}}
-            node-parameters: true
+            node-parameters: false
             condition: 'UNSTABLE_OR_BETTER'
           - project:
               report-consolidated-coverage-{satellite_version}-{os}


### PR DESCRIPTION
fixes the issue with queued downstream builds which have no available agent.
The parameter is apparently used to inherit the same node from the parent build.

This doesn't work as the node is destroyed straight after parent job is finished, leading to infinite wait for the node with the same label.