### PR TITLE
Add component-owners-mapping YAML generating job and pipeline

### DIFF
--- a/jobs/satellite6-component-owners.yaml
+++ b/jobs/satellite6-component-owners.yaml
@@ -1,0 +1,23 @@
+- job:
+    name: 'satellite6-component-owners'
+    concurrent: false
+    display-name: 'Satellite 6 Component Owners and testimony.json'
+    description: |
+        Job that updates component owners map on Mojo based on data from bugzilla, and creates YAML file with component primary and secondary
+        owners. It also creates testimony.json file from current robottelo master.
+    parameters:
+        - bool:
+            name: UPDATE_MOJO
+            default: True
+        - string:
+            name: MOJO_DOC_ID
+            default: 'DOC-1191673'
+        - bool:
+            name: IGNORE_CACHE
+            default: False
+    project-type: pipeline
+    dsl:
+        !include-raw:
+            - workflows/qe/satellite6-component-owners.groovy
+    triggers:
+      - timed: "@midnight"

--- a/vars/defaults.groovy
+++ b/vars/defaults.groovy
@@ -4,6 +4,7 @@ class defaults implements Serializable {
     String venvModule = 'virtualenv'
 
     String automation_tools = 'https://github.com/SatelliteQE/automation-tools'
+    String robottelo = 'https://github.com/SatelliteQE/robottelo/'
     String robottelo_ci = 'https://github.com/SatelliteQE/robottelo-ci'
     String apix = 'https://github.com/JacobCallahan/apix'
     String clix = 'https://github.com/JacobCallahan/clix'

--- a/workflows/qe/satellite6-component-owners.groovy
+++ b/workflows/qe/satellite6-component-owners.groovy
@@ -1,0 +1,122 @@
+@Library("github.com/SatelliteQE/robottelo-ci") _
+
+pipeline {
+    agent {
+        label 'sat6-rhel'
+    }
+    options {
+        buildDiscarder(logRotator(numToKeepStr:'20'))
+        disableConcurrentBuilds()
+    }
+    stages {
+        stage('Create Virtualenv') {
+            steps {
+                make_venv([
+                    venv: "${env.WORKSPACE}/venv",
+                    python: defaults.python
+                ])
+            }
+        }
+        stage('Clone satellite6-reporting repo') {
+            steps {
+                configFileProvider(
+                [configFile(fileId: '4d08176d-ab32-4830-93bc-1cc6e9003b0f', variable: 'SAT6_REPORTING')]) {
+                    sh_venv([
+                        venv: "${env.WORKSPACE}/venv",
+                        script: "source \${SAT6_REPORTING}"
+                    ])
+                }
+            }
+        }
+        stage('Prepare satellite6-reporting') {
+            steps {
+                dir("satellite6-reporting") {
+                    sh_venv([
+                        venv: "${env.WORKSPACE}/venv",
+                        script: """
+                            pip install -r requirements.txt
+                            """
+                    ])
+                }
+            }
+        }
+        stage('Generate component-owners-map.yaml file') {
+            steps {
+                withCredentials([usernamePassword(credentialsId: 'mojo', passwordVariable: 'MOJO_PASSWORD', usernameVariable: 'MOJO_USER')]) {
+                    dir("satellite6-reporting/component-owners") {
+                        sh_venv([
+                            venv: "${env.WORKSPACE}/venv",
+                            script: com_cmd(MOJO_USER, MOJO_PASSWORD, 'print -f component-owners-map.yaml')
+                        ])
+                    }
+                }
+            }
+        }
+        stage('Update Mojo') {
+            when {
+                expression { return params.UPDATE_MOJO }
+            }
+            steps {
+                withCredentials([usernamePassword(credentialsId: 'mojo', passwordVariable: 'MOJO_PASSWORD', usernameVariable: 'MOJO_USER')]) {
+                    dir("satellite6-reporting/component-owners") {
+                        sh_venv([
+                            venv: "${env.WORKSPACE}/venv",
+                            script: com_cmd(MOJO_USER, MOJO_PASSWORD, 'update')
+                        ])
+                    }
+                }
+            }
+        }
+        stage('Prepare Robottelo') {
+            steps {
+                dir("robottelo") {
+                    git defaults.robottelo
+                    sh_venv([
+                        venv: "${env.WORKSPACE}/venv",
+                        script:"""
+                            export PYCURL_SSL_LIBRARY=\$(curl -V | sed -n 's/.*\\(NSS\\|OpenSSL\\).*/\\L\\1/p')
+                            pip install -r requirements.txt
+                            """
+                    ])
+                }
+            }
+        }
+        stage('Create testimony.json file') {
+            steps {
+                dir("robottelo") {
+                    sh_venv([
+                        venv: "${env.WORKSPACE}/venv",
+                        script:"""
+                            testimony -c testimony.yaml --json print tests/foreman/ > testimony.json
+                            """
+                    ])
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            archiveArtifacts(artifacts: "**/component-owners-map.yaml, **/testimony.json")
+        }
+    }
+}
+
+def com_cmd(String mojo_user, String mojo_password, String command) {
+    script {
+        force = ''
+        if (params.IGNORE_CACHE) {
+            force = '--force'
+        }
+        cmd = """
+        ./component-owners-manager
+            --user '${mojo_user}'
+            --password '${mojo_password}'
+            --doc '${params.MOJO_DOC_ID}'
+            ${force}
+            ${command}
+        """
+        out = cmd.split('\n').join(' ')
+        return out
+    }
+}


### PR DESCRIPTION
My first attempt at Jenkins job.

Main goal is to create component-owners-mapping.yaml file, which contains machine-readable data about components and their owners (d'oh!). That file will be consumed by satellite6-report-portal pipeline during tagging/email sending and by Bruno's [bugzilla nagger script](https://github.com/SatelliteQE/robottelo/issues/7336), and possibly by others in the future.

This is not yet ready to merge due to multiple dependencies, but I want to get feedback, and I have to start these changes somewhere.

* changes to satellite6-reporting repo submitted in <SAT_GITLAB>/satelliteqe/satellite6-reporting/merge_requests/3 - **merged**
* updating Mojo using script right now will change Mojo table; I asked management for confirmation they are acceptable - **got green light from mgmt**
* changes to report-portal-tools submitted  in <SAT_GITLAB>/satelliteqe/report-portal-tools/merge_requests/26 - **merged**
* changes to satellite6-report-portal pipeline (to consume files produced here) will be raised in separate PR later