### PR TITLE
tell tool belt which snap version we're releasing

### DIFF
--- a/workflows/lib/releaseQAFunctions.groovy
+++ b/workflows/lib/releaseQAFunctions.groovy
@@ -119,6 +119,7 @@ def generate_snap_data(args) {
                 options: [
                     "--version ${args.release_stream}",
                     "--milestone ${args.release_version}",
+                    "--snap ${args.snap_version}",
                     "--gitlab-username jenkins",
                     "--gitlab-token ${env.GITLAB_TOKEN}",
                     "--bz-username ${env.BZ_USERNAME}",
@@ -145,7 +146,8 @@ def release_snap(args) {
         version: "${args.release_name}/${args.release_version}",
         release_name: args.release_name,
         release_version: args.release_version,
-        release_stream: args.release_stream
+        release_stream: args.release_stream,
+        snap_version: args.snap_version
     )
 
     send_snap_mail(


### PR DESCRIPTION
in some cases, the computed version is wrong

(depends on toolbelt understanding this first)