### PR TITLE
skip repoclosure for EL6 and older

### DIFF
--- a/ansible/playbooks/build_compose.yml
+++ b/ansible/playbooks/build_compose.yml
@@ -19,7 +19,7 @@
         path: "{{ compose_link.stdout }}"
 
     - name: 'Generate compose'
-      command: "pungi-koji --test --config={{ compose_conf_dir }}/pungi/satellite-6/{{ compose_version }}/{{ compose_name }}-rhel-{{ rhel_version }}-{{ compose_tag }}.conf --target-dir={{ compose_output_dir }} --skip-phase=createiso --skip-phase=live_images --skip-phase=extra_files"
+      command: "pungi-koji --test --config={{ compose_conf_dir }}/pungi/satellite-6/{{ compose_version }}/{{ compose_name }}-rhel-{{ rhel_version }}-{{ compose_tag }}.conf --target-dir={{ compose_output_dir }} --skip-phase=createiso --skip-phase=live_images --skip-phase=extra_files {{ '--skip-phase=test' if rhel_version is version('6', '<=') else '' }}"
 
     - name: 'Find repos to cleanup'
       find:


### PR DESCRIPTION
repoclosure is an expensive task (takes up to ten minutes per target on our infra).
as we don't change EL5 and EL6 repos much anyways, let's just run
closure for EL7 and EL8