### PR TITLE
Use correct selector

### DIFF
--- a/workflows/qe/satellite6-report-portal.groovy
+++ b/workflows/qe/satellite6-report-portal.groovy
@@ -23,7 +23,7 @@ pipeline {
         stage('Obtain component-owners-map.yaml and testimony.json') {
             steps {
                 copyArtifacts(projectName: 'satellite6-component-owners',
-                    selector: 'lastSuccessful',
+                    selector: lastSuccessful(),
                     target: 'rp_tools/scripts/reportportal_cli/'
                 )
             }


### PR DESCRIPTION
Apparently, I'm supposed to [call `lastSuccessful()` function](https://github.com/jenkinsci/copyartifact-plugin/blob/master/src/test/java/hudson/plugins/copyartifact/CopyArtifactWorkflowTest.java#L302), not pass this as a string. Hope it will work.