### PR TITLE
Create files in $WORKSPACE

### DIFF
--- a/lib/python/satellite6-polarion-test-case-inject.py
+++ b/lib/python/satellite6-polarion-test-case-inject.py
@@ -130,6 +130,6 @@ get_product_versions(
 )
 
 inject_component_owners(
-    component_owners_yaml="satellite6-reporting/component-owners/component-owners-map.yaml",
+    component_owners_yaml="component-owners-map.yaml",
     xml_file_path="polarion-test-cases.xml"
 )

--- a/workflows/qe/satellite6-component-owners.groovy
+++ b/workflows/qe/satellite6-component-owners.groovy
@@ -46,7 +46,7 @@ pipeline {
                     dir("satellite6-reporting/component-owners") {
                         sh_venv([
                             venv: "${env.WORKSPACE}/venv",
-                            script: com_cmd(MOJO_USER, MOJO_PASSWORD, 'print -f component-owners-map.yaml')
+                            script: com_cmd(MOJO_USER, MOJO_PASSWORD, 'print -f ../../component-owners-map.yaml')
                         ])
                     }
                 }
@@ -87,7 +87,7 @@ pipeline {
                     sh_venv([
                         venv: "${env.WORKSPACE}/venv",
                         script:"""
-                            testimony -c testimony.yaml --json print tests/foreman/ > testimony.json
+                            testimony -c testimony.yaml --json print tests/foreman/ > ../testimony.json
                             """
                     ])
                 }


### PR DESCRIPTION
I did not realize that `archiveArtifacts()` maintains directory structure. As a result, dependent jobs received `satellite6-reporting/component-owners/component-owners-map.yaml` and `robottelo/testimony.json`, instead of just `component-owners-map.yaml` and `testimony.json`. 

This caused report portal run #59 to fail to correctly tag test failures with owners, as files were in different place that `rp_cli.py` was looking for them.

I already tested this in satellite-component-owners run #58. See also results of satellite6-report-portal #60.