### PR TITLE
Fix satellite6-custom-certs-automation for missing '6.7' choice

### DIFF
--- a/jobs/custom-certs-automation.yaml
+++ b/jobs/custom-certs-automation.yaml
@@ -30,11 +30,11 @@
         - choice:
             name: SATELLITE_VERSION
             choices:
+                - '6.7'
                 - '6.6'
                 - '6.5'
                 - '6.4'
                 - '6.3'
-                - '6.2'
             description: |
                 <p>Select Satellite version to install.</p>
         - choice:
@@ -49,11 +49,11 @@
         - choice:
             name: UPGRADE_TO_VERSION
             choices:
+                - '6.7'
                 - '6.6'
                 - '6.5'
                 - '6.4'
                 - '6.3'
-                - '6.2'
             description: |
                 <p>Select Satellite version to upgrade. Mandatory if ACTION selected is upgrade.</p>
         - choice:


### PR DESCRIPTION
Fixes provisioning-6.7-rhel7 for:
```
ERROR: Build step failed with exception
java.lang.IllegalArgumentException: Illegal choice for parameter SATELLITE_VERSION: 6.7
	at hudson.model.ChoiceParameterDefinition.checkValue(ChoiceParameterDefinition.java:138)
	at hudson.model.ChoiceParameterDefinition.createValue(ChoiceParameterDefinition.java:150)
	at hudson.model.ChoiceParameterDefinition.createValue(ChoiceParameterDefinition.java:25)
```