### PR TITLE
backup hammer config before automation run and restore it after

### DIFF
--- a/workflows/qe/satellite6-automation/satellite6-tiers.groovy
+++ b/workflows/qe/satellite6-automation/satellite6-tiers.groovy
@@ -237,6 +237,10 @@ options {
     '''
      EXTRA_MARKS = SATELLITE_VERSION.contains("*upstream-nightly*") ? '' : "and upgrade"
   }
+  withCredentials([sshUserPrivateKey(credentialsId: 'id_hudson_rsa', keyFileVariable: 'identity', usernameVariable: 'userName')]) {
+    remote = [name: "Satellite server", allowAnyHosts: true, host: SERVER_HOSTNAME, user: userName, identityFile: identity]
+    sshCommand remote: remote, command: 'cp /root/.hammer/cli.modules.d/foreman.yml{,_orig}'
+  }
   }
   }
   stage("Run Destructive tests"){
@@ -356,6 +360,7 @@ post {
             [$class: 'StabilityTestDataPublisher']],
             testResults: '*-results.xml'
              remote = [name: "Satellite server", allowAnyHosts: true, host: SERVER_HOSTNAME, user: userName, identityFile: identity]
+             sshCommand remote: remote, command: 'cp /root/.hammer/cli.modules.d/foreman.yml{_orig,}'
              sshCommand remote: remote, command: 'foreman-debug -s 0 -q -d "/tmp/foreman-debug"'
              sshGet remote: remote, from: '/tmp/foreman-debug.tar.xz', into: '.', override: true
              // Start Code coverage


### PR DESCRIPTION
`foreman-debug` now sources user credentials from
`/root/.hammer/cli.modules.d/foreman.yml`; which is being manipulated by robottelo cli tests (`test_auth.py`).
Since the tests remove the credentials (and any test can touch this config in the future), this negatively affects the pipeline as it uses the foreman-debug utility to archive artifacts and the missing credentials cause the script to stall (waiting for login credentials).

- this solution should make it independent on what we do in the tests by simply backing up the file before and restoring it after the automation si done.