### PR TITLE
Limit number of concurrent Satellites to 3

### DIFF
--- a/jobs/satellite6-automation/satellite6-tiers.yaml
+++ b/jobs/satellite6-automation/satellite6-tiers.yaml
@@ -20,15 +20,19 @@
             projects:
               - name: 'automation-{satellite_version}-tier1-{os}'
                 current-parameters: true
+              - name: 'automation-{satellite_version}-rhai-{os}'
+                current-parameters: true
+              - name: 'automation-{satellite_version}-destructive-{os}'
+                current-parameters: true
+        - multijob:
+            name: PhaseTwo
+            condition: UNSTABLE
+            projects:
               - name: 'automation-{satellite_version}-tier2-{os}'
                 current-parameters: true
               - name: 'automation-{satellite_version}-tier3-{os}'
                 current-parameters: true
               - name: 'automation-{satellite_version}-tier4-{os}'
-                current-parameters: true
-              - name: 'automation-{satellite_version}-destructive-{os}'
-                current-parameters: true
-              - name: 'automation-{satellite_version}-rhai-{os}'
                 current-parameters: true
     publishers:
         - trigger-parameterized-builds:


### PR DESCRIPTION
Limit number of concurrent Satellites to 3 as we need more RAM per instance.
Minimum is 20GB and while we use 16GB only and mongod suffers from OOM errors

Expected overal automation run-time will get longer of Tier1 runtime (= 2 hrs)


Relates to MR!288