### PR TITLE
don't wait for satellite-trigger jobs to complete in release-qa

### DIFF
--- a/workflows/releaseQAWorkflow.groovy
+++ b/workflows/releaseQAWorkflow.groovy
@@ -151,10 +151,12 @@ node('sat6-build') {
 
 node {
     stage("Run Automation") {
-        build job: "trigger-satellite-${satellite_main_version}", parameters: [
-          [$class: 'StringParameterValue', name: 'SATELLITE_DISTRIBUTION', value: 'INTERNAL'],
-          [$class: 'StringParameterValue', name: 'BUILD_LABEL', value: "Satellite ${full_snap_version}"],
-        ]
+        build job: "trigger-satellite-${satellite_main_version}",
+          parameters: [
+            [$class: 'StringParameterValue', name: 'SATELLITE_DISTRIBUTION', value: 'INTERNAL'],
+            [$class: 'StringParameterValue', name: 'BUILD_LABEL', value: "Satellite ${full_snap_version}"],
+          ],
+          wait: false
     }
 }
 


### PR DESCRIPTION
in b4f3b9291f8afac267982586bcd9d157f5d49821 the satellite-trigger job
was converted to a pipeline that waits for its children, so now we wait
too. let's explicitly set wait: false and not wait for the trigger.