### PR TITLE
Fix base url for sanity

### DIFF
--- a/workflows/qe/satellite6-automation/satellite6-trigger.groovy
+++ b/workflows/qe/satellite6-automation/satellite6-trigger.groovy
@@ -94,7 +94,7 @@ pipeline {
      steps {
       build job: "satellite6-sanity-check-${satellite_version}-rhel7",
        parameters: [
-        string(name: 'BASE_URL', value: "${RHEL8_SATELLITE_URL}"),
+        string(name: 'BASE_URL', value: "${RHEL7_SATELLITE_URL}"),
         string(name: 'SELINUX_MODE', value: "${params.SELINUX_MODE}"),
         string(name: 'SATELLITE_DISTRIBUTION', value: "${params.SATELLITE_DISTRIBUTION}"),
         string(name: 'PROXY_MODE', value: "${params.PROXY_MODE}"),


### PR DESCRIPTION
```
Executing task 'downstream_install'
The BASE_URL environment variable should be defined
```