### PR TITLE
update foreman.yml restore command to be warn-only (return 0)

### DIFF
--- a/workflows/qe/satellite6-automation/satellite6-tiers.groovy
+++ b/workflows/qe/satellite6-automation/satellite6-tiers.groovy
@@ -348,7 +348,7 @@ post {
             [$class: 'StabilityTestDataPublisher']],
             testResults: '*-results.xml'
              remote = [name: "Satellite server", allowAnyHosts: true, host: SERVER_HOSTNAME, user: userName, identityFile: identity]
-             sshCommand remote: remote, command: 'cp /root/.hammer/cli.modules.d/foreman.yml{_orig,}'
+             sshCommand remote: remote, command: 'cp /root/.hammer/cli.modules.d/foreman.yml{_orig,}||:'
              sshCommand remote: remote, command: 'foreman-debug -s 0 -q -d "/tmp/foreman-debug"'
              sshGet remote: remote, from: '/tmp/foreman-debug.tar.xz', into: '.', override: true
              // Start Code coverage


### PR DESCRIPTION
This is a simple commit to prevent any error to occur during the foreman.yml restoration in the job teardown. It still prints the error message for investigation purposes, but doesn't bring the whole job down. 
It happened in the wild that the step which was responsible for creating the backup failed, so there was no file to be restored, and our teardown failed as the `cp` command didn't find the backup file, generating a misleading error.

```
$ touch foo_orig
$ ls foo*
foo_orig
$ cp foo{_orig,}||:
$ ls foo*
foo  foo_orig
$ cp nonexistingfile{_orig,}||:
cp: cannot stat 'nonexistingfile_orig': No such file or directory
$ echo $?
0
$ ls nonexist*
ls: cannot access 'nonexist*': No such file or directory
```