### PR TITLE
Use no-proxy till ginger comes online

### DIFF
--- a/jobs/parameters/satellite6_provisioning_parameters.yaml
+++ b/jobs/parameters/satellite6_provisioning_parameters.yaml
@@ -9,9 +9,9 @@
         - choice:
             name: PROXY_MODE
             choices:
+                - 'no-proxy'
                 - 'authenticated'
                 - 'non-authenticated'
-                - 'no-proxy'
         - string:
             name: ROBOTTELO_WORKERS
             default: '8'

--- a/jobs/satellite6-automation/satellite6-sanity.yaml
+++ b/jobs/satellite6-automation/satellite6-sanity.yaml
@@ -31,9 +31,9 @@
         - choice:
             name: PROXY_MODE
             choices:
+                - 'no-proxy'
                 - 'authenticated'
                 - 'non-authenticated'
-                - 'no-proxy'
         - string:
             name: ADMIN_PASSWORD
             default: changeme

--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -52,9 +52,9 @@
         - choice:
             name: PROXY_MODE
             choices:
+                - 'no-proxy'
                 - 'authenticated'
                 - 'non-authenticated'
-                - 'no-proxy'
         - bool:
             name: PARTITION_DISK
             default: true

--- a/jobs/satellite6-libvirt-install.yaml
+++ b/jobs/satellite6-libvirt-install.yaml
@@ -62,9 +62,9 @@
         - choice:
             name: PROXY_MODE
             choices:
+                - 'no-proxy'
                 - 'authenticated'
                 - 'non-authenticated'
-                - 'no-proxy'
         - string:
             name: ADMIN_PASSWORD
             default: changeme


### PR DESCRIPTION
If ginger issue not resolved till next snap landing, we have to run the automation without proxy.

Will revert this PR, once we have new proxy or ginger started working fine.