### PR TITLE
Fixed bash typo

### DIFF
--- a/scripts/satellite6-standalone-automation.sh
+++ b/scripts/satellite6-standalone-automation.sh
@@ -26,7 +26,7 @@ else
     sed -i "s|capsule_repo.*|capsule_repo=${CAPSULE_REPO}|" robottelo.properties
 fi
 
-if [-n "${ROBOTTELO_YAML:-}" ]; then
+if [ -n "${ROBOTTELO_YAML:-}" ]; then
     echo "${ROBOTTELO_YAML}" > ./robottelo.yaml
 else
     cp config/robottelo.yaml ./robottelo.yaml


### PR DESCRIPTION
The missing space between `[` and `-n`] is causing an error when you specify ROBOTTELO_YAML environment variable as a parameter