### PR TITLE
Convert parameter to string, rather than treat it as float.

### DIFF
--- a/vars/branch_selection.groovy
+++ b/vars/branch_selection.groovy
@@ -5,7 +5,7 @@
     ex : branch_selection("6.6")
 */
 def call(satellite_version) {
-    satellite_version = satellite_version ?: '6.7'
+    satellite_version = satellite_version ? satellite_version.toString() : '6.7'
     branch_name=["6.3": "6.3.z","6.4": "6.4.z", "6.5": "6.5.z", "6.6": "6.6.z"]
     def branch = satellite_version in branch_name?branch_name[satellite_version]:"master"
     return branch


### PR DESCRIPTION
This bug caused master branches of repos to be used instead of z branches.