### PR TITLE
Send email on component-owners failure

### DIFF
--- a/workflows/qe/satellite6-component-owners.groovy
+++ b/workflows/qe/satellite6-component-owners.groovy
@@ -99,6 +99,12 @@ pipeline {
         always {
             archiveArtifacts(artifacts: "**/component-owners-map.yaml, **/testimony.json")
         }
+        failure {
+            send_automation_email "failure"
+        }
+        fixed {
+            send_automation_email "fixed"
+        }
     }
 }
 


### PR DESCRIPTION
Following up `"Failed test" emails` thread on mailing list - send email on job failure, so we prevent situation where job fails for a month straight and nobody notices.

Question: Where is `QE_EMAIL_LIST` variable defined? Where this email will be sent?