### PR TITLE
converting gstring to string to make the conditional functional

### DIFF
--- a/workflows/qe/satellite6-automation/satellite6-tiers.groovy
+++ b/workflows/qe/satellite6-automation/satellite6-tiers.groovy
@@ -106,7 +106,7 @@ options {
       rename_cmd = "${rename_cmd} ${SERVER_HOSTNAME} -y -u admin -p changeme"
       sshCommand remote: remote, command: rename_cmd
 
-      if (!("${ENDPOINT}" in ["tier3", "tier4"])){
+      if (!("${ENDPOINT}".toString() in ["tier3", "tier4"])){
         sshCommand remote: remote, command: "systemctl stop dhcpd"
       }
      }


### PR DESCRIPTION
Apparently the `"${VAR}"` isn't an ordinary `String` in java, but rather a [GString](https://docs.groovy-lang.org/latest/html/api/groovy/lang/GString.html#toString--). the `foo in [bar, baz]`statement  always evaluates to `False` for GStrings (TIL).
Thus, we need to build a `String` object from it first.

the result should be equivalent to this:
```groovy
def ENDPOINT="tier2";

if (!("${ENDPOINT}".toString() in ["tier3", "tier4"])){
  print("systemctl stop dhcpd");
}
else{
  print('doing nothing');
}
```
(you can test it e.g at https://groovyconsole.appspot.com/)