### PR TITLE
Revert "Throttle the katello and foreman unittest job to only run 3 c…

### DIFF
--- a/jobs/properties/throttle-katello-unittest-pipelines.yaml
+++ b/jobs/properties/throttle-katello-unittest-pipelines.yaml
@@ -1,9 +1,0 @@
-- property:
-    name: satellite6-katello-unittest-throttle
-    properties:
-      - throttle:
-          max-per-node: 3
-          max-total: 3
-          categories:
-            - katello-unittest
-          option: category

--- a/jobs/unittest/sat6-unit-test-foreman.yaml
+++ b/jobs/unittest/sat6-unit-test-foreman.yaml
@@ -20,4 +20,3 @@
         - workflows/lib/gitlab.groovy
     notifications:
       - snapper_notifications
-

--- a/jobs/unittest/sat6-unit-test-katello.yaml
+++ b/jobs/unittest/sat6-unit-test-katello.yaml
@@ -20,6 +20,3 @@
         - workflows/lib/gitlab.groovy
     notifications:
       - snapper_notifications
-    properties:
-      - satellite6-katello-unittest-throttle
-


### PR DESCRIPTION
…oncurrent jobs at a time."

This reverts commit bc6afc4142fdc22b0cdc743714842fc5fe374154.

There is an odd interaction between our Gitlab integration and the throttle plugin that stop the Gitlab integration from functioning. Until a fix for this has been found I think the Gitlab integration is more important. 