### PR TITLE
Use betelgeuse 1.6.0

### DIFF
--- a/jobs/satellite6-betelgeuse.yaml
+++ b/jobs/satellite6-betelgeuse.yaml
@@ -24,7 +24,7 @@
         - shining-panda:
             build-environment: virtualenv
             name: betelgeuse
-            python-version: System-CPython-2.7
+            python-version: System-CPython-3.6
             clear: true
             nature: shell
             command:
@@ -166,7 +166,7 @@
         - shining-panda:
             build-environment: virtualenv
             name: betelgeuse
-            python-version: System-CPython-2.7
+            python-version: System-CPython-3.6
             clear: true
             nature: shell
             command:
@@ -204,7 +204,7 @@
         - shining-panda:
             build-environment: virtualenv
             name: betelgeuse
-            python-version: System-CPython-2.7
+            python-version: System-CPython-3.6
             clear: true
             nature: shell
             command:
@@ -259,7 +259,7 @@
         - shining-panda:
             build-environment: virtualenv
             name: betelgeuse
-            python-version: System-CPython-2.7
+            python-version: System-CPython-3.6
             clear: true
             nature: shell
             command:

--- a/lib/python/satellite6-polarion-test-plan.py
+++ b/lib/python/satellite6-polarion-test-plan.py
@@ -44,7 +44,15 @@ def load_custom_fields(custom_fields_opt):
 
 
 def create_test_plan(name, plan_type, parent_name, custom_fields, project):
-    """Create a new test plan in Polarion."""
+    """Create a new test plan in Polarion.
+
+    :param name: Name for new Test Plan
+    :param plan_type: Test Plan type; one of "release" or "iteration"
+    :param parent_name: Name of parent Test Plan to link to
+    :param custom_fields: Custom fields for the test plan
+    :param project: Name of Polarion project
+    """
+
     # Sanitize names to valid values for IDs...
     custom_fields = load_custom_fields(custom_fields)
     plan_id = re.sub(INVALID_CHARS_REGEX, '_', name).replace(' ', '_')
@@ -55,7 +63,7 @@ def create_test_plan(name, plan_type, parent_name, custom_fields, project):
 
     # Check if the test plan already exists
     result = Plan.search(f'id:{plan_id}')
-    if len(result) == 1:
+    if result:
         logging.info(f'Found Test Plan {name}.')
         test_plan = result[0]
     else:

--- a/lib/python/satellite6-polarion-test-plan.py
+++ b/lib/python/satellite6-polarion-test-plan.py
@@ -1,0 +1,114 @@
+#!/usr/bin/python
+"""This wrapper around pylarion that creates test plan in Polarion.
+
+Re-implementation of `betelgeuse test-plan` subcommand. betelgeuse >1.0
+deprecated `test-plan` without providing alternative, and we require
+it in our process.
+
+Usage::
+
+    $ python satellite6-polarion-test-case-inject.py
+"""
+import argparse
+import json
+import logging
+import re
+import time
+
+from pylarion.plan import Plan
+
+INVALID_CHARS_REGEX = re.compile(r'[\\/.:"<>|~!@#$?%^&\'*()+`,=]')
+
+
+def load_custom_fields(custom_fields_opt):
+    """Load the custom fields from the --custom-fields option.
+
+    The --custom-fields option can receive either a string on the format
+    ``key=value`` or a JSON string ``{"key":"value"}``, which will be loaded
+    into a dictionary.
+
+    If the value passed is not in JSON or key=value format it will be ignored.
+
+    :param custom_fields_opt: A tuple of --custom-fields option.
+    """
+    custom_fields = {}
+    if not custom_fields_opt:
+        return custom_fields
+    for item in custom_fields_opt:
+        if item.startswith('{'):
+            custom_fields.update(json.loads(item))
+        elif '=' in item:
+            key, value = item.split('=', 1)
+            custom_fields[key.strip()] = value.strip()
+    return custom_fields
+
+
+def create_test_plan(name, plan_type, parent_name, custom_fields, project):
+    """Create a new test plan in Polarion."""
+    # Sanitize names to valid values for IDs...
+    custom_fields = load_custom_fields(custom_fields)
+    plan_id = re.sub(INVALID_CHARS_REGEX, '_', name).replace(' ', '_')
+    parent_plan_id = (
+        re.sub(INVALID_CHARS_REGEX, '_', parent_name).replace(' ', '_')
+        if parent_name else parent_name
+    )
+
+    # Check if the test plan already exists
+    result = Plan.search('id:{0}'.format(plan_id))
+    if len(result) == 1:
+        logging.info('Found Test Plan {0}.'.format(name))
+        test_plan = result[0]
+    else:
+        # Unlike Testrun, Pylarion currently does not accept **kwargs in
+        # Plan.create() so the custom fields need to be updated after the
+        # creation
+        test_plan = Plan.create(
+            parent_id=parent_plan_id,
+            plan_id=plan_id,
+            plan_name=name,
+            project_id=project,
+            template_id=plan_type
+        )
+        logging.info(
+            'Created new Test Plan {0} with ID {1}.'.format(name, plan_id)
+        )
+
+    update = False
+    for field, value in custom_fields.items():
+        if getattr(test_plan, field) != value:
+            setattr(test_plan, field, value)
+            logging.info(
+                'Test Plan {0} updated with {1}={2}.'.format(
+                    test_plan.name, field, value)
+            )
+            update = True
+    if update:
+        test_plan.update()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Re-implementation of "betelgeuse test-plan".')
+    parser.add_argument('--name', default=f'test-plan-{time.time()}',
+                        help='Name for new Test Plan.')
+    parser.add_argument('--plan-type', default='release',
+                        help='Test Plan type; one of "release" or "iteration"')
+    parser.add_argument('--parent-name',
+                        help='Name of parent Test Plan to link to.')
+    parser.add_argument('--custom-fields', action='append',
+                        help='Custom fields for the test plan.')
+    parser.add_argument('project', nargs='+',
+                        help='Name of Polarion project to use.')
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+
+    if args.plan_type not in ('release', 'iteration'):
+        raise SystemExit('--plan-type must be one of "release", "iteration"')
+
+    create_test_plan(args.name, args.plan_type, args.parent_name,
+                     args.custom_fields, args.project)

--- a/lib/python/satellite6-polarion-test-plan.py
+++ b/lib/python/satellite6-polarion-test-plan.py
@@ -54,9 +54,9 @@ def create_test_plan(name, plan_type, parent_name, custom_fields, project):
     )
 
     # Check if the test plan already exists
-    result = Plan.search('id:{0}'.format(plan_id))
+    result = Plan.search(f'id:{plan_id}')
     if len(result) == 1:
-        logging.info('Found Test Plan {0}.'.format(name))
+        logging.info(f'Found Test Plan {name}.')
         test_plan = result[0]
     else:
         # Unlike Testrun, Pylarion currently does not accept **kwargs in
@@ -69,17 +69,14 @@ def create_test_plan(name, plan_type, parent_name, custom_fields, project):
             project_id=project,
             template_id=plan_type
         )
-        logging.info(
-            'Created new Test Plan {0} with ID {1}.'.format(name, plan_id)
-        )
+        logging.info(f'Created new Test Plan {name} with ID {plan_id}.')
 
     update = False
     for field, value in custom_fields.items():
         if getattr(test_plan, field) != value:
             setattr(test_plan, field, value)
             logging.info(
-                'Test Plan {0} updated with {1}={2}.'.format(
-                    test_plan.name, field, value)
+                f'Test Plan {test_plan.name} updated with {field}={value}.'
             )
             update = True
     if update:

--- a/scripts/satellite6-betelgeuse-test-case.sh
+++ b/scripts/satellite6-betelgeuse-test-case.sh
@@ -1,5 +1,5 @@
 # Install the latest version of betelgeuse.
-pip install Betelgeuse==0.16.0 pathlib pyyaml
+pip install Betelgeuse==1.6.0 pyyaml
 
 
 if [[ ${BETELGEUSE_AUTOMATION_PROJECT} = "satellite6-upgrade" ]]; then
@@ -11,7 +11,12 @@ fi
 for TC_PATH in $(echo ${BETELGEUSE_TC_PATH}) ; do \
 betelgeuse requirement \
     ${TC_PATH} \
-    "${POLARION_PROJECT}" ; done
+    "${POLARION_PROJECT}" \
+    "requirement.xml" ; \
+curl -k -u "${POLARION_USERNAME}:${POLARION_PASSWORD}" \
+    -X POST \
+    -F file=@requirement.xml \
+    "${POLARION_URL}import/requirement" ; done
 
 export PYTHONPATH="${PWD}"
 

--- a/scripts/satellite6-betelgeuse-test-run.sh
+++ b/scripts/satellite6-betelgeuse-test-run.sh
@@ -1,13 +1,14 @@
 # Populate token-prefix and betelgeuse depending upon Satellite6 Version.
 
-pip install Betelgeuse==0.16.0
+pip install Betelgeuse==1.6.0
 TOKEN_PREFIX=""
 
-# Create a new release with POLARION_RELEASE as the parent-plan.
+wget https://raw.githubusercontent.com/SatelliteQE/robottelo-ci/master/lib/python/satellite6-polarion-test-plan.py
 
+# Create a new release with POLARION_RELEASE as the parent-plan.
 if [ -n "$POLARION_RELEASE" ]; then
-    betelgeuse test-plan --name "${POLARION_RELEASE}" --plan-type release \
-    "${POLARION_PROJECT}"
+    python satellite6-polarion-test-plan.py --name "${POLARION_RELEASE}" \
+        --plan-type release "${POLARION_PROJECT}"
 else
     echo "Please specify the POLARION_RELEASE"
     exit 1
@@ -15,10 +16,11 @@ fi
 
 # Create a new iteration for the current run
 if [ -n "$POLARION_RELEASE" ]; then
-    betelgeuse test-plan --name "${TEST_RUN_ID}" --parent-name "${POLARION_RELEASE}" \
+    python satellite6-polarion-test-plan.py --name "${TEST_RUN_ID}" \
+        --parent-name "${POLARION_RELEASE}" \
         --plan-type iteration "${POLARION_PROJECT}"
 else
-    betelgeuse test-plan --name "${TEST_RUN_ID}" \
+    python satellite6-polarion-test-plan.py --name "${TEST_RUN_ID}" \
         --plan-type iteration "${POLARION_PROJECT}"
 fi
 
@@ -31,7 +33,7 @@ TEST_RUN_GROUP_ID="$(echo ${TEST_RUN_ID} | cut -d' ' -f2)"
 if [[ "${TEST_RUN_ID}" = *"upgrade"* ]]; then
     # All tiers result upload
     for run in parallel sequential; do
-        betelgeuse ${TOKEN_PREFIX} xml-test-run \
+        betelgeuse ${TOKEN_PREFIX} test-run \
         --custom-fields "isautomated=true" \
         --custom-fields "arch=x8664" \
         --custom-fields "variant=server" \
@@ -50,7 +52,7 @@ if [[ "${TEST_RUN_ID}" = *"upgrade"* ]]; then
         "${POLARION_URL}import/xunit"
     done
     # end-to-end tier results upload
-    betelgeuse ${TOKEN_PREFIX} xml-test-run \
+    betelgeuse ${TOKEN_PREFIX} test-run \
     --custom-fields "isautomated=true" \
     --custom-fields "arch=x8664" \
     --custom-fields "variant=server" \
@@ -68,7 +70,7 @@ if [[ "${TEST_RUN_ID}" = *"upgrade"* ]]; then
     -F file=@polarion-smoke-upgrade-results.xml \
     "${POLARION_URL}import/xunit"
 elif [ "${ENDPOINT}" = "rhai" ] || [ "${ENDPOINT}" = "destructive" ]; then
-    betelgeuse ${TOKEN_PREFIX} xml-test-run \
+    betelgeuse ${TOKEN_PREFIX} test-run \
         --custom-fields "isautomated=true" \
         --custom-fields "arch=x8664" \
         --custom-fields "variant=server" \
@@ -87,7 +89,7 @@ elif [ "${ENDPOINT}" = "rhai" ] || [ "${ENDPOINT}" = "destructive" ]; then
         "${POLARION_URL}import/xunit"
 else
     for run in parallel sequential; do
-        betelgeuse ${TOKEN_PREFIX} xml-test-run \
+        betelgeuse ${TOKEN_PREFIX} test-run \
             --custom-fields "isautomated=true" \
             --custom-fields "arch=x8664" \
             --custom-fields "variant=server" \
@@ -108,7 +110,7 @@ else
 fi
 
 # Mark the iteration done
-betelgeuse test-plan \
+python satellite6-polarion-test-plan.py \
     --name "${TEST_RUN_ID}" \
     --custom-fields status=done \
     "${POLARION_PROJECT}"

--- a/scripts/satellite6-install-pylarion.sh
+++ b/scripts/satellite6-install-pylarion.sh
@@ -3,7 +3,6 @@ git clone ${PYLARION_REPO_URL}
 
 # Install pylarion and its dependencies
 cd pylarion
-git checkout origin/satelliteqe-pylarion
 pip install -r requirements.txt
 pip install .
 cd ..


### PR DESCRIPTION
Update betelgeuse to Py3-compatible version. This should allow this part of CI to be Py3-compatible and, more importantly, robottelo tests to be Py3-compatible (i.e. avoid problems like https://github.com/SatelliteQE/robottelo/pull/7460 ).

Summary of changes;
* send requirements using curl; betelgeuse dropped pylarion dependency, now it just generates local XML files  that should be uploaded to Polarion importers through other means
* rename `xml-test-run` to `test-run` - they both do the same thing in 0.16, but 1.0 dropped backward dependency on command name
* introduce `satellite6-polarion-test-plan.py` command and use it in place of `betelgeuse test-plan`; betelgeuse lost support for this command and there is no importer to which we could send XML. We need thin wrapper around pylarion, and this command does exactly that. It's very much a copy of [betelgeuse test-plan](https://github.com/SatelliteQE/betelgeuse/blob/f9d3c0ba04382c01ed40d13d31fc53eda632a44e/betelgeuse/__init__.py#L337) function.
* Stop using pylarion satelliteqe-pylarion custom fork - there is no need for that. internal pylarion fork master is updated to upstream pylarion master (this is needed for Python3 compatibility). I also submitted PR in gitlab to rebase `satelliteqe-pylarion` branch on top of current master.


Questions:
1. Do we have to use backslashes in `.sh` scripts (`scripts/satellite6-betelgeuse-test-case.sh`)? Why are they necessary?
2. Is there better way to use script from /lib/ than `wget`ing it? I just follow pattern established in `scripts/satellite6-betelgeuse-test-case.sh`, but it feels wierd.
3. What is the best way for me to actually test these changes? I am aware of "test Jenkins", but last time I used it, it was configured differently than our prod instance. These scripts depend on global variables which are defined in Jenkins itself, and since I don't have admin there, I don't have access to their content.