### PR TITLE
Fix baseimage name inconsistency between automation-tools and robottelo

### DIFF
--- a/jobs/satellite6-automation/satellite6-provisioning.yaml
+++ b/jobs/satellite6-automation/satellite6-provisioning.yaml
@@ -43,7 +43,7 @@
         - string:
             name: IMAGE
             description: |
-                Specify custom RHEL source image to be used for automation. Do not use the full path, use the image name without the .img suffix
+                Specify custom RHEL source image to be used for automation. Do not use the full path, use the image name without the "-base.img" suffix
         - bool:
             name: PYTHON_CODE_COVERAGE
             default: true

--- a/scripts/satellite6-provisioning.sh
+++ b/scripts/satellite6-provisioning.sh
@@ -73,7 +73,7 @@ echo "DISCOVERY_ISO=${DISCOVERY_ISO}" >> build_env.properties
 # Run installation after writing the build_env.properties to make sure the
 # values are available for the post build actions, specially the foreman-debug
 # capturing.
-fab -D -H "root@${PROVISIONING_HOST}" "vm_create:target_image=${TARGET_IMAGE},source_image=${SOURCE_IMAGE},bridge=${BRIDGE}"
+fab -D -H "root@${PROVISIONING_HOST}" "vm_create:target_image=${TARGET_IMAGE},source_image=${SOURCE_IMAGE}-base,bridge=${BRIDGE}"
 fab -D -H "root@${SERVER_HOSTNAME}" "product_install:${DISTRIBUTION},sat_version=${SATELLITE_VERSION},test_in_stage=${STAGE_TEST},puppet4=${PUPPET4}"
 
 echo


### PR DESCRIPTION
automation-tools requires `rhel77-base`
   vs.
robottelo requires just `rhel77`

You can pass custom (RHEL RC) image using IMAGE job param, but then in robottelo tests i fails as it appends "-base" , resulting in ```rhel77-base-base.img not found```

Fixed so that provisioning appends "-base" the same way as robottelo does.

Depends on satelliteqe/jenkins-configs `MR!314`