### PR TITLE
Disabled latest sauce connect. 

### DIFF
--- a/jobs/wrappers/satellite6_sauceondemand_wrappers.yaml
+++ b/jobs/wrappers/satellite6_sauceondemand_wrappers.yaml
@@ -14,7 +14,7 @@
                   <webDriverBrowsers/>
                   <appiumBrowsers/>
                   <useLatestVersion>false</useLatestVersion>
-                  <useLatestSauceConnect>true</useLatestSauceConnect>
+                  <useLatestSauceConnect>false</useLatestSauceConnect>
                   <forceCleanup>true</forceCleanup>
                   <launchSauceConnectOnSlave>true</launchSauceConnectOnSlave>
                   <verboseLogging>true</verboseLogging>


### PR DESCRIPTION
We are facing some problems with the latest sauce-connect plugin(sc-4.6.0), due to that we are unable to execute sauce connect to command and get an error like below.

`Error: unknown command "" for "sc"`

And it has blocked our execution thus we have decided to use the bundled sc plugin to unblock the execution, In the future, if some fix comes around that then we will rollback the current changes.