### PR TITLE
always destroy the forklift box

### DIFF
--- a/workflows/lib/libvirt.groovy
+++ b/workflows/lib/libvirt.groovy
@@ -27,8 +27,11 @@ def test_forklift(args) {
                 try {
                     runOnLibvirtHost "cd sat-deploy && ansible-playbook pipelines/${satellite_product}_install_pipeline.yml -e forklift_state=up ${extra_vars}"
                 } finally {
-                    runOnLibvirtHost "cd sat-deploy && ansible-playbook forklift/playbooks/collect_debug.yml -l 'pipeline-*' ${extra_vars}"
-                    runOnLibvirtHost "cd sat-deploy && ansible-playbook pipelines/${satellite_product}_install_pipeline.yml -e forklift_state=destroy ${extra_vars}"
+                    try {
+                        runOnLibvirtHost "cd sat-deploy && ansible-playbook forklift/playbooks/collect_debug.yml -l 'pipeline-*-${satellite_version}-rhel${item}' ${extra_vars}"
+                    } finally {
+                        runOnLibvirtHost "cd sat-deploy && ansible-playbook pipelines/${satellite_product}_install_pipeline.yml -e forklift_state=destroy ${extra_vars}"
+                    }
 
                     def debug_folder = "debug-${satellite_product}-${satellite_version}-rhel${item}"
 


### PR DESCRIPTION
in some cases, debug collection can fail (e.g. when the box hung or so)
and thus the forklift box remains present.

also make debug collection more specific to the running box, as there
might be other pipelines running in parallel