### PR TITLE
Split 6.7 and 6.8 to 6.7.z and master branch

### DIFF
--- a/jobs/satellite6-automation/satellite6-projects.yaml
+++ b/jobs/satellite6-automation/satellite6-projects.yaml
@@ -12,7 +12,8 @@
             scm-branch: origin/6.5.z
         - '6.6':
             scm-branch: origin/6.6.z
-        - '6.7'
+        - '6.7':
+            scm-branch: origin/6.7.z
         - '6.8'
         - 'upstream-nightly':
             rp_project: 'katello-nightly'
@@ -86,7 +87,8 @@
             scm-branch: origin/6.5.z
         - '6.6':
             scm-branch: origin/6.6.z
-        - '6.7'
+        - '6.7':
+            scm-branch: origin/6.7.z
         - '6.8'
     os:
         - 'rhel7'

--- a/vars/branch_selection.groovy
+++ b/vars/branch_selection.groovy
@@ -10,6 +10,7 @@ def call(String satellite_version='6.8') {
         "6.4": "6.4.z",
         "6.5": "6.5.z",
         "6.6": "6.6.z",
+        "6.7": "6.7.z",
     ]
     def branch = satellite_version in branch_map ? branch_map[satellite_version] : "master"
     return branch


### PR DESCRIPTION
Small but important change as we have branched 6.7.z:
- `6.8` automation -> `master` branch
- `6.7` automation -> `6.7.z` branch