### PR TITLE
Replace 'katello-service' by 'foreman-maintain service'

### DIFF
--- a/scripts/satellite6-automation-instances.sh
+++ b/scripts/satellite6-automation-instances.sh
@@ -44,7 +44,7 @@ function setup_instance () {
     ssh $ssh_opts root@"${SERVER_HOSTNAME}" hostnamectl set-hostname "${TIER_SOURCE_IMAGE%%-base}.${VM_DOMAIN}"
     ssh $ssh_opts root@"${SERVER_HOSTNAME}" sed -i '/redhat.com/d' /etc/hosts
     ssh $ssh_opts root@"${SERVER_HOSTNAME}" "echo ${TIER_IPADDR} ${TIER_SOURCE_IMAGE%%-base}.${VM_DOMAIN} ${TIER_SOURCE_IMAGE%%-base} >> /etc/hosts"
-    ssh $ssh_opts root@"${SERVER_HOSTNAME}" 'katello-service restart'
+    ssh $ssh_opts root@"${SERVER_HOSTNAME}" 'foreman-maintain service restart'
     wait_for_hammerping "${SERVER_HOSTNAME}" 240
 
     # changing Satellite6 hostname (supported on Sat6.2+)

--- a/scripts/satellite6-graceful-shutdown.sh
+++ b/scripts/satellite6-graceful-shutdown.sh
@@ -2,7 +2,7 @@ ssh_opts='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
 
 echo "Shutting down the Base instance of ${SERVER_HOSTNAME} gracefully"
 # Shutdown the Satellite6 services before shutdown.
-ssh $ssh_opts root@"${SERVER_HOSTNAME}" katello-service stop
+ssh $ssh_opts root@"${SERVER_HOSTNAME}" foreman-maintain service stop
 # Try to shutdown the Satellite6 instance gracefully and sleep for a while.
 ssh $ssh_opts root@"${PROVISIONING_HOST}" virsh shutdown ${TARGET_IMAGE}
 sleep 120

--- a/scripts/satellite6-handle-tier-instances.sh
+++ b/scripts/satellite6-handle-tier-instances.sh
@@ -15,7 +15,7 @@ if [ "${ACTION}" = "start" ]; then
         ssh $ssh_opts root@"${PROVISIONING_HOST}" virsh start ${TARGET_IMAGE}
         set -e
         sleep 60
-        ssh $ssh_opts root@"${TARGET_BASE_IMAGE%%-base}-${ENDPOINT}.${VM_DOMAIN}" katello-service restart
+        ssh $ssh_opts root@"${TARGET_BASE_IMAGE%%-base}-${ENDPOINT}.${VM_DOMAIN}" foreman-maintain service restart
     elif [ $RESULT -eq 0 ]; then
         echo "An instance with IP: ${IPADDR} is already running and so cannot start this instance."
         echo "Shutdown other instances using the IP: ${IPADDR} and then start this instance."
@@ -29,7 +29,7 @@ elif [ "${ACTION}" = "shutdown" ]; then
     echo "========================================"
     echo " Shutdown the instances of ${TARGET_IMAGE} virsh domain."
     echo "========================================"
-    ssh $ssh_opts root@"${TARGET_BASE_IMAGE%%-base}-${ENDPOINT}.${VM_DOMAIN}" katello-service stop
+    ssh $ssh_opts root@"${TARGET_BASE_IMAGE%%-base}-${ENDPOINT}.${VM_DOMAIN}" foreman-maintain service stop
     set +e
     # Gracefully shutdown the vm instance.
     ssh $ssh_opts root@"${PROVISIONING_HOST}" virsh shutdown ${TARGET_IMAGE}

--- a/workflows/qe/satellite6-automation/satellite6-tiers.groovy
+++ b/workflows/qe/satellite6-automation/satellite6-tiers.groovy
@@ -89,7 +89,7 @@ options {
       sshCommand remote: remote, command: "hostnamectl set-hostname ${tier_name}"
       sshCommand remote: remote, command: "sed -i '/redhat.com/d' /etc/hosts"
       sshCommand remote: remote, command: "echo ${TIER_IPADDR} ${tier_name} ${tier_short_name} >> /etc/hosts"
-      sshCommand remote: remote, command: "katello-service restart"
+      sshCommand remote: remote, command: "foreman-maintain service restart"
       timeout(time: 4, unit: 'MINUTES') {
        retry(240) {
         sleep(10)
@@ -419,7 +419,7 @@ def get_code_coverage(String ENDPOINT, String coverage) {
     remote = [name: "Satellite server", allowAnyHosts: true, host: SERVER_HOSTNAME, user: userName, identityFile: identity]
     if (coverage == 'python') {
         // Shutdown the Satellite6 services for collecting coverage.
-        sshCommand remote: remote, command: 'katello-service stop || true'
+        sshCommand remote: remote, command: 'foreman-maintain service stop || true'
         // Create tar file for each of the Tier .coverage files to create a consolidated coverage report.
         sshCommand remote: remote, command: "cd /etc/coverage ; tar -cvf coverage.${ENDPOINT}.tar .coverage.*"
         // Combine the coverage output to a single file and create a xml file.


### PR DESCRIPTION
for Satellite 6.8 there is no `katello-service` command eventually