### PR TITLE
Added manifest refresh in sanity job script.

### DIFF
--- a/scripts/satellite6-populate-template.sh
+++ b/scripts/satellite6-populate-template.sh
@@ -209,6 +209,7 @@ satellite_runner settings set --name default_download_policy --value "${DOWNLOAD
 
 # Import Manifest.
 satellite_runner subscription upload --organization-id "${ORG}" --file "${HOME}"/manifest-latest.zip
+satellite_runner subscription refresh --organization-id "${ORG}"
 
 # Enable Red Hat repositories
 # Kickstart trees


### PR DESCRIPTION
Most of the red hat repositories listed the empty version list with the attached manifest file, but after refreshing the manifests all the repos listed properly. 
This fix will solve the sanity job failure problem.