### PR TITLE
Include Stubbed/Manual Tests in Polarion

### DIFF
--- a/jobs/satellite6-standalone-automation.yaml
+++ b/jobs/satellite6-standalone-automation.yaml
@@ -62,7 +62,7 @@
                 parameter will be ignored</strong>.</p>
         - string:
             name: PYTEST_MARKS
-            default: not stubbed
+            default: stubbed
             description: |
                 Specify the py.test marks you want to run or skip when specifying PYTEST_OPTIONS.
         - string:

--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -100,13 +100,13 @@ elif [ "${ENDPOINT}" != "rhai" ]; then
     # Run sequential tests
     $(which py.test) -v --junit-xml="${ENDPOINT}-sequential-results.xml" \
         -o junit_suite_name="${ENDPOINT}-sequential" \
-        -m "${ENDPOINT} and run_in_one_thread and not stubbed ${EXTRA_MARKS}" \
+        -m "${ENDPOINT} and run_in_one_thread ${EXTRA_MARKS}" \
         ${TEST_TYPE}
 
     # Run parallel tests
     $(which py.test) -v --junit-xml="${ENDPOINT}-parallel-results.xml" -n "${ROBOTTELO_WORKERS}" \
         -o junit_suite_name="${ENDPOINT}-parallel" \
-        -m "${ENDPOINT} and not run_in_one_thread and not stubbed ${EXTRA_MARKS}" \
+        -m "${ENDPOINT} and not run_in_one_thread ${EXTRA_MARKS}" \
         ${TEST_TYPE}
     set -e
 else

--- a/scripts/satellite6-upgrade-tier-source.sh
+++ b/scripts/satellite6-upgrade-tier-source.sh
@@ -102,14 +102,14 @@ if [ "${ENDPOINT}" != "end-to-end" ]; then
     # Run all tiers sequential tests with upgrade mark
     $(which py.test) -v --junit-xml="${ENDPOINT}-upgrade-sequential-results.xml" \
         -o junit_suite_name="${ENDPOINT}-upgrade-sequential" \
-        -m "upgrade and run_in_one_thread and not stubbed" \
+        -m "upgrade and run_in_one_thread" \
         ${TEST_TYPE}
 
     # Run all tiers parallel tests with upgrade mark
 
     $(which py.test) -v --junit-xml="${ENDPOINT}-upgrade-parallel-results.xml" -n "${ROBOTTELO_WORKERS}" \
         -o junit_suite_name="${ENDPOINT}-upgrade-parallel" \
-        -m "upgrade and not run_in_one_thread and not stubbed" \
+        -m "upgrade and not run_in_one_thread" \
         ${TEST_TYPE}
     set -e
 elif [ "${ENDPOINT}" == "end-to-end" ]; then

--- a/workflows/qe/satellite6-automation/satellite6-tiers.groovy
+++ b/workflows/qe/satellite6-automation/satellite6-tiers.groovy
@@ -276,7 +276,7 @@ stages {
           # Run sequential tests
           $(which py.test) -v --junit-xml="${ENDPOINT}-sequential-results.xml" \
             -o junit_suite_name="${ENDPOINT}-sequential" \
-            -m "${ENDPOINT} and run_in_one_thread and not stubbed ${EXTRA_MARKS}" \
+            -m "${ENDPOINT} and run_in_one_thread ${EXTRA_MARKS}" \
             ${TEST_TYPE}
           set -e
         '''
@@ -296,7 +296,7 @@ stages {
           # Run parallel tests
           $(which py.test) -v --junit-xml="${ENDPOINT}-parallel-results.xml" -n "${ROBOTTELO_WORKERS}" \
             -o junit_suite_name="${ENDPOINT}-parallel" \
-            -m "${ENDPOINT} and not run_in_one_thread and not stubbed ${EXTRA_MARKS}" \
+            -m "${ENDPOINT} and not run_in_one_thread ${EXTRA_MARKS}" \
             ${TEST_TYPE}
           set -e
         '''


### PR DESCRIPTION
This PR includes changes in scripts and jobs :

- [x] To include the stubbed/manual tests in pytest's junit-xml.

Then while uploading(curl) the results to polarion, the skipped tests results will also be skipped and will remain in waiting status, until component owner mark it as executed.

To know about the investigation and assuring it works, look at the jira ticket : SATQE-9667.
