### PR TITLE
Archive swatch reports

### DIFF
--- a/workflows/qe/satellite6-automation/satellite6-tiers.groovy
+++ b/workflows/qe/satellite6-automation/satellite6-tiers.groovy
@@ -375,8 +375,9 @@ post {
           sourceEncoding: 'ASCII',
           zoomCoverageChart: false
       }
+      sh 'cp /var/tmp/report_for*.tar.gz ./'
     }
-    archiveArtifacts(artifacts: 'robottelo*.log,*-results.xml,foreman-debug.tar.xz,coverage.*.tar,tfm_reports_*.tar,screenshots/*/*.png,robottelo.properties', allowEmptyArchive: true)
+    archiveArtifacts(artifacts: 'robottelo*.log,*-results.xml,foreman-debug.tar.xz,coverage.*.tar,tfm_reports_*.tar,screenshots/*/*.png,robottelo.properties,report_for*.tar.gz', allowEmptyArchive: true)
     withCredentials([sshUserPrivateKey(credentialsId: 'id_hudson_rsa', keyFileVariable: 'identity',usernameVariable: 'userName')]) {
       script {
         remote = [name: "Provisioning serverr", allowAnyHosts: true, host: PROVISIONING_HOST, user: userName, identityFile: identity]

--- a/workflows/qe/satellite6-automation/satellite6-tiers.groovy
+++ b/workflows/qe/satellite6-automation/satellite6-tiers.groovy
@@ -375,7 +375,7 @@ post {
           sourceEncoding: 'ASCII',
           zoomCoverageChart: false
       }
-      sh 'cp /var/tmp/report_for*.tar.gz ./'
+      sh 'cp /var/tmp/report_for*.tar.gz ./ ||:'
     }
     archiveArtifacts(artifacts: 'robottelo*.log,*-results.xml,foreman-debug.tar.xz,coverage.*.tar,tfm_reports_*.tar,screenshots/*/*.png,robottelo.properties,report_for*.tar.gz', allowEmptyArchive: true)
     withCredentials([sshUserPrivateKey(credentialsId: 'id_hudson_rsa', keyFileVariable: 'identity',usernameVariable: 'userName')]) {


### PR DESCRIPTION
Once [robottelo #7882](https://github.com/SatelliteQE/robottelo/pull/7882) is merged and run, it will leave inventory report behind in `/var/tmp/` of runner. We want to provide this report to swatch QE team, so they can run their own automation on it.

In this PR, I copy all reports from `/var/tmp` to workspace and add them to list of artifacts to archive.

This is very much short-term solution. Long-term, we hope to have *something* that will allow us to store these reports in more structured way, along with some additional metadata that swatch QE might need (package versions, output of selected hammer commands). At that point I will probably introduce new Python script or workflow step to do the work.