### PR TITLE
Updated rhev cert environment variable in upgrade

### DIFF
--- a/workflows/qe/upgrade-pipeline/satellite6-upgrade-phase.groovy
+++ b/workflows/qe/upgrade-pipeline/satellite6-upgrade-phase.groovy
@@ -144,6 +144,7 @@ def loading_the_groovy_script_to_build_upgrade_phase_environment(){
         source ${CONFIG_FILES}
     '''
     load('config/compute_resources.groovy')
+    load('config/installation_environment.groovy')
     load('config/sat6_upgrade.groovy')
     load('config/sat6_repos_urls.groovy')
     load('config/subscription_config.groovy')
@@ -156,6 +157,7 @@ def loading_the_groovy_script_to_build_upgrade_phase_environment(){
 }
 
 def environment_variable_for_upgrade() {
+    env.HTTP_SERVER_HOSTNAME = HTTP_SERVER_HOSTNAME
     // required for product_upgrade task from satellite6-upgrade
     env.RHEV_USER = RHEV_USER
     env.RHEV_PASSWD = RHEV_PASSWD

--- a/workflows/qe/upgrade-pipeline/satellite6-upgrade-trigger.groovy
+++ b/workflows/qe/upgrade-pipeline/satellite6-upgrade-trigger.groovy
@@ -108,7 +108,6 @@ def loading_the_groovy_script_to_build_environment(){
      configFileProvider([configFile(fileId: 'bc5f0cbc-616f-46de-bdfe-2e024e84fcbf', variable: 'CONFIG_FILES')]) {
         sh_venv '''source ${CONFIG_FILES}'''
         load('config/compute_resources.groovy')
-        load('config/installation_environment.groovy')
         load('config/sat6_upgrade.groovy')
         load('config/sat6_repos_urls.groovy')
         load('config/subscription_config.groovy')
@@ -119,7 +118,6 @@ def loading_the_groovy_script_to_build_environment(){
 }
 
 def environment_variable_for_setup_upgrade() {
-    env.HTTP_SERVER_HOSTNAME = HTTP_SERVER_HOSTNAME
     // required for get_rhevm4_client() from satellite6-upgrade
     env.RHEV_USER = RHEV_USER
     env.RHEV_PASSWD = RHEV_PASSWD


### PR DESCRIPTION
The post-upgrade task gets failed in upgrade due to unable to get the required environment variable to update the RHEVM cert.