### PR TITLE
Update betelgeuse testrun and testplan uploads to set in progress status

### DIFF
--- a/scripts/satellite6-betelgeuse-test-run.sh
+++ b/scripts/satellite6-betelgeuse-test-run.sh
@@ -38,6 +38,7 @@ if [[ "${TEST_RUN_ID}" = *"upgrade"* ]]; then
         --custom-fields "arch=x8664" \
         --custom-fields "variant=server" \
         --custom-fields "plannedin=${SANITIZED_ITERATION_ID}" \
+        --custom-fields "status=in_progress" \
         --response-property "${POLARION_SELECTOR}" \
         --test-run-id "${TEST_RUN_ID} - ${run} - Tier all-tiers" \
         --test-run-group-id "${TEST_RUN_GROUP_ID}" \
@@ -57,6 +58,7 @@ if [[ "${TEST_RUN_ID}" = *"upgrade"* ]]; then
     --custom-fields "arch=x8664" \
     --custom-fields "variant=server" \
     --custom-fields "plannedin=${SANITIZED_ITERATION_ID}" \
+    --custom-fields "status=in_progress" \
     --response-property "${POLARION_SELECTOR}" \
     --test-run-id "${TEST_RUN_ID} - Tier end-to-end" \
     --test-run-group-id "${TEST_RUN_GROUP_ID}" \
@@ -75,6 +77,7 @@ elif [ "${ENDPOINT}" = "rhai" ] || [ "${ENDPOINT}" = "destructive" ]; then
         --custom-fields "arch=x8664" \
         --custom-fields "variant=server" \
         --custom-fields "plannedin=${SANITIZED_ITERATION_ID}" \
+        --custom-fields "status=in_progress" \
         --response-property "${POLARION_SELECTOR}" \
         --test-run-id "${TEST_RUN_ID} - ${ENDPOINT##tier}" \
         --test-run-group-id "${TEST_RUN_GROUP_ID}" \
@@ -94,6 +97,7 @@ else
             --custom-fields "arch=x8664" \
             --custom-fields "variant=server" \
             --custom-fields "plannedin=${SANITIZED_ITERATION_ID}" \
+            --custom-fields "status=in_progress" \
             --response-property "${POLARION_SELECTOR}" \
             --test-run-id "${TEST_RUN_ID} - ${run} - Tier ${ENDPOINT##tier}" \
             --test-run-group-id "${TEST_RUN_GROUP_ID}" \
@@ -112,5 +116,4 @@ fi
 # Mark the iteration done
 python satellite6-polarion-test-plan.py \
     --name "${TEST_RUN_ID}" \
-    --custom-fields status=done \
     "${POLARION_PROJECT}"


### PR DESCRIPTION
We are including some manual test cases in these runs, and don't want to set their status to Done.

It looks like the default behavior here for betelgeuse is to set Done status on testruns, as there is nothing specified currently.
Within polarion, setting the test plan to Done does not set all included testruns to Done state, so I don't think its the use of `status=done` on the satellite6-polarion-test-plan.py script call that is setting testrun status too.