### PR TITLE
don't abort the whole step on test failure

### DIFF
--- a/workflows/qe/satellite6-foreman-ansible-modules-automation.groovy
+++ b/workflows/qe/satellite6-foreman-ansible-modules-automation.groovy
@@ -73,14 +73,14 @@ pipeline {
                             if (env.REPLAY == 'true') {
                                 sh_venv '''
                                 while read -r module; do
-                                    make test_$module
+                                    make test_$module || true
                                 done < module_list
                                 '''
                             }
                             else {
                                 sh_venv '''
                                 while read -r module; do
-                                    make record_$module
+                                    make record_$module || true
                                 done < module_list
                                 '''
                             }


### PR DESCRIPTION
Apparently Jenkins executes shell commands with `set -e` causing any test failure to break the loop and abort the step. This PR is to let the whole test loop finish