### PR TITLE
Use betelgeuse test-run --status arg

### DIFF
--- a/scripts/satellite6-betelgeuse-test-case.sh
+++ b/scripts/satellite6-betelgeuse-test-case.sh
@@ -1,5 +1,5 @@
 # Install the latest version of betelgeuse.
-pip install Betelgeuse==1.6.0 pyyaml
+pip install Betelgeuse==1.7.0 pyyaml
 
 
 if [[ ${BETELGEUSE_AUTOMATION_PROJECT} = "satellite6-upgrade" ]]; then

--- a/scripts/satellite6-betelgeuse-test-run.sh
+++ b/scripts/satellite6-betelgeuse-test-run.sh
@@ -38,10 +38,10 @@ if [[ "${TEST_RUN_ID}" = *"upgrade"* ]]; then
         --custom-fields "arch=x8664" \
         --custom-fields "variant=server" \
         --custom-fields "plannedin=${SANITIZED_ITERATION_ID}" \
-        --custom-fields "status=in_progress" \
         --response-property "${POLARION_SELECTOR}" \
         --test-run-id "${TEST_RUN_ID} - ${run} - Tier all-tiers" \
         --test-run-group-id "${TEST_RUN_GROUP_ID}" \
+        --status inprogress \
         "./all-tiers-upgrade-${run}-results.xml" \
         tests/foreman \
         "${POLARION_USERNAME}" \
@@ -58,10 +58,10 @@ if [[ "${TEST_RUN_ID}" = *"upgrade"* ]]; then
     --custom-fields "arch=x8664" \
     --custom-fields "variant=server" \
     --custom-fields "plannedin=${SANITIZED_ITERATION_ID}" \
-    --custom-fields "status=in_progress" \
     --response-property "${POLARION_SELECTOR}" \
     --test-run-id "${TEST_RUN_ID} - Tier end-to-end" \
     --test-run-group-id "${TEST_RUN_GROUP_ID}" \
+    --status inprogress \
     "./smoke-tests-results.xml" \
     tests/foreman \
     "${POLARION_USERNAME}" \
@@ -77,10 +77,10 @@ elif [ "${ENDPOINT}" = "rhai" ] || [ "${ENDPOINT}" = "destructive" ]; then
         --custom-fields "arch=x8664" \
         --custom-fields "variant=server" \
         --custom-fields "plannedin=${SANITIZED_ITERATION_ID}" \
-        --custom-fields "status=in_progress" \
         --response-property "${POLARION_SELECTOR}" \
         --test-run-id "${TEST_RUN_ID} - ${ENDPOINT##tier}" \
         --test-run-group-id "${TEST_RUN_GROUP_ID}" \
+        --status inprogress \
         "./foreman-results.xml" \
         tests/foreman \
         "${POLARION_USERNAME}" \
@@ -97,10 +97,10 @@ else
             --custom-fields "arch=x8664" \
             --custom-fields "variant=server" \
             --custom-fields "plannedin=${SANITIZED_ITERATION_ID}" \
-            --custom-fields "status=in_progress" \
             --response-property "${POLARION_SELECTOR}" \
             --test-run-id "${TEST_RUN_ID} - ${run} - Tier ${ENDPOINT##tier}" \
             --test-run-group-id "${TEST_RUN_GROUP_ID}" \
+            --status inprogress \
             "./tier${ENDPOINT##tier}-${run}-results.xml" \
             tests/foreman \
             "${POLARION_USERNAME}" \

--- a/scripts/satellite6-betelgeuse-test-run.sh
+++ b/scripts/satellite6-betelgeuse-test-run.sh
@@ -1,6 +1,6 @@
 # Populate token-prefix and betelgeuse depending upon Satellite6 Version.
 
-pip install Betelgeuse==1.6.0
+pip install Betelgeuse==1.7.0
 TOKEN_PREFIX=""
 
 wget https://raw.githubusercontent.com/SatelliteQE/robottelo-ci/master/lib/python/satellite6-polarion-test-plan.py


### PR DESCRIPTION
Thanks @jyejare for catching this!

Betelgeuse's help text for test-run includes something not in the ReadTheDocs text - a `status` option! Use it to directly set status for testruns, instead of via custom-field values (that were probably wrong anyway).