### PR TITLE
Add virtwho.properties file to pre/post upgrade process

### DIFF
--- a/workflows/qe/upgrade-pipeline/satellite6-postupgrade-scenario-tests.groovy
+++ b/workflows/qe/upgrade-pipeline/satellite6-postupgrade-scenario-tests.groovy
@@ -136,6 +136,7 @@ def loading_the_groovy_script_to_build_post_upgrade_environment(){
         source ${CONFIG_FILES}
         cp config/robottelo.properties ./robottelo.properties
         cp config/robottelo.yaml ./robottelo.yaml
+        cp config/virtwho.properties ./virtwho.properties
         sed -i "s/'robottelo.log'/'robottelo-${ENDPOINT}.log'/" logging.conf
     '''
     load('config/compute_resources.groovy')

--- a/workflows/qe/upgrade-pipeline/satellite6-preupgrade-scenario-tests.groovy
+++ b/workflows/qe/upgrade-pipeline/satellite6-preupgrade-scenario-tests.groovy
@@ -125,6 +125,7 @@ def loading_the_groovy_script_to_build_pre_upgrade_environment(){
         source ${CONFIG_FILES}
         cp config/robottelo.properties ./robottelo.properties
         cp config/robottelo.yaml ./robottelo.yaml
+        cp config/virtwho.properties ./virtwho.properties
         sed -i "s/'robottelo.log'/'robottelo-${ENDPOINT}.log'/" logging.conf
     '''
     load('config/compute_resources.groovy')


### PR DESCRIPTION
**Description**
The PR(https://github.com/SatelliteQE/robottelo/pull/8020) was merged, now we need to read the hypervisor configs by virtwho.properties file, so need to add the step to pre/post upgrade CI

This PR depends on [satelliteqe/jenkins-configs/!351](https://gitlab.sat.engineering.redhat.com/satelliteqe/jenkins-configs/-/merge_requests/351)