### PR TITLE
satellite6-report-portal uses RPv4 branch by default

### DIFF
--- a/jobs/satellite6-report-portal.yaml
+++ b/jobs/satellite6-report-portal.yaml
@@ -18,7 +18,7 @@
             default: 'satelliteqe'
         - string:
             name: RP_TOOLS_BRANCH
-            default: 'master'
+            default: 'RPv4'
         - string:
             name: WORKERS
             default: '8'


### PR DESCRIPTION
We branched report_portal_tools to make backwards-incompatible changes to support RPv5. Until we migrate to the RPv5, we will use the RPv4 branch by default.