### PR TITLE
pytest-xdist is now included in requirements.txt

### DIFF
--- a/scripts/satellite6-automation.sh
+++ b/scripts/satellite6-automation.sh
@@ -1,4 +1,4 @@
-pip install -U -r requirements.txt docker-py pytest-xdist==1.25.0 sauceclient
+pip install -U -r requirements.txt docker-py sauceclient
 
 cp config/robottelo.properties ./robottelo.properties
 cp config/robottelo.yaml ./robottelo.yaml

--- a/scripts/satellite6-standalone-automation.sh
+++ b/scripts/satellite6-standalone-automation.sh
@@ -3,7 +3,7 @@ set -o nounset
 source ${CONFIG_FILES}
 source config/sat6_repos_urls.conf
 
-pip install -U -r requirements.txt docker-py pytest-xdist==1.25.0 sauceclient
+pip install -U -r requirements.txt docker-py sauceclient
 
 if [ -n "${ROBOTTELO_PROPERTIES:-}" ]; then
     echo "${ROBOTTELO_PROPERTIES}" > ./robottelo.properties

--- a/scripts/satellite6-upgrade-run-scenarios.sh
+++ b/scripts/satellite6-upgrade-run-scenarios.sh
@@ -1,6 +1,6 @@
 
 function setupRequirement () {
-    pip install -U -r requirements.txt docker-py pytest-xdist==1.27.0 sauceclient
+    pip install -U -r requirements.txt docker-py sauceclient
     pip install -r requirements-optional.txt
 }
 

--- a/scripts/satellite6-upgrade-tier-source.sh
+++ b/scripts/satellite6-upgrade-tier-source.sh
@@ -1,4 +1,4 @@
-pip install -U -r requirements.txt docker-py pytest-xdist==1.25.0 sauceclient
+pip install -U -r requirements.txt docker-py sauceclient
 pip install -r requirements-optional.txt
  # Sourcing and exporting required env vars for tier jobs
 source ${CONFIG_FILES}

--- a/scripts/satellite6_upgrader.sh
+++ b/scripts/satellite6_upgrader.sh
@@ -1,7 +1,7 @@
 # ==================================================== Define Functions for both in common processes =====================================
 
 function setupRequirement () {
-    pip install -U -r requirements.txt docker-py pytest-xdist==1.27.0
+    pip install -U -r requirements.txt docker-py 
     pip install -r requirements-optional.txt
 }
 

--- a/workflows/qe/nailgun-reviewer.groovy
+++ b/workflows/qe/nailgun-reviewer.groovy
@@ -33,7 +33,7 @@ pipeline {
                     cp config/robottelo.properties ./robottelo.properties
                     sed -i "s|@stable-satellite#egg=nailgun|@refs/pull/${ghprbPullId}/head|g" requirements.txt
                     export PYCURL_SSL_LIBRARY=\$(curl -V | sed -n 's/.*\\(NSS\\|OpenSSL\\).*/\\L\\1/p')
-                    pip install -r requirements.txt docker-py pytest-xdist==1.25.0 sauceclient
+                    pip install -r requirements.txt docker-py sauceclient
                '''
                script {
                    def DATA="${env.ghprbCommentBody}"

--- a/workflows/qe/satellite6-automation/satellite6-tiers.groovy
+++ b/workflows/qe/satellite6-automation/satellite6-tiers.groovy
@@ -233,7 +233,7 @@ stages {
     steps {
       script {
         sh_venv '''
-          pip install -U -r requirements.txt docker-py pytest-xdist==1.25.0 sauceclient
+          pip install -U -r requirements.txt docker-py sauceclient
         '''
         EXTRA_MARKS = SATELLITE_VERSION.contains("*upstream-nightly*") ? '' : "and upgrade"
       }

--- a/workflows/qe/upgrade-pipeline/satellite6-postupgrade-scenario-tests.groovy
+++ b/workflows/qe/upgrade-pipeline/satellite6-postupgrade-scenario-tests.groovy
@@ -24,7 +24,7 @@ pipeline {
                     # Installing nailgun according to FROM_VERSION
                     sed -i "s/nailgun.git.*/nailgun.git@${FROM_VERSION}.z#egg=nailgun/" requirements.txt
                     export PYCURL_SSL_LIBRARY=\$(curl -V | sed -n 's/.*\\(NSS\\|OpenSSL\\).*/\\L\\1/p')
-                    pip install -U -r requirements.txt docker-py pytest-xdist==1.27.0 sauceclient
+                    pip install -U -r requirements.txt docker-py sauceclient
                     pip install -r requirements-optional.txt
                 '''
                 }

--- a/workflows/qe/upgrade-pipeline/satellite6-preupgrade-scenario-tests.groovy
+++ b/workflows/qe/upgrade-pipeline/satellite6-preupgrade-scenario-tests.groovy
@@ -24,7 +24,7 @@ pipeline {
                     # Installing nailgun according to FROM_VERSION
                     sed -i "s/nailgun.git.*/nailgun.git@${FROM_VERSION}.z#egg=nailgun/" requirements.txt
                     export PYCURL_SSL_LIBRARY=\$(curl -V | sed -n 's/.*\\(NSS\\|OpenSSL\\).*/\\L\\1/p')
-                    pip install -U -r requirements.txt docker-py pytest-xdist==1.27.0 sauceclient
+                    pip install -U -r requirements.txt docker-py sauceclient
                     pip install -r requirements-optional.txt
                 '''
                 }

--- a/workflows/qe/upgrade-pipeline/satellite6-upgraded-all-tiers.groovy
+++ b/workflows/qe/upgrade-pipeline/satellite6-upgraded-all-tiers.groovy
@@ -24,7 +24,7 @@ pipeline {
                     # Installing nailgun according to FROM_VERSION
                     sed -i "s/nailgun.git.*/nailgun.git@${FROM_VERSION}.z#egg=nailgun/" requirements.txt
                     export PYCURL_SSL_LIBRARY=\$(curl -V | sed -n 's/.*\\(NSS\\|OpenSSL\\).*/\\L\\1/p')
-                    pip install -U -r requirements.txt docker-py pytest-xdist==1.27.0 sauceclient
+                    pip install -U -r requirements.txt docker-py sauceclient
                     pip install -r requirements-optional.txt
                 '''
                 }


### PR DESCRIPTION
https://github.com/SatelliteQE/robottelo/pull/7997 made `pytest-xdist` mandatory and listed in requirements.txt 
This started to conflict with explicitly defined pytest-xdist in CI.

Fixes:
```
+ pip install -U -r requirements.txt docker-py pytest-xdist==1.25.0 sauceclient
ERROR: Double requirement given: pytest-xdist==1.34.0 (from -r requirements.txt (line 17)) (already in pytest-xdist==1.25.0, name='pytest-xdist')
```