### PR TITLE
Update freestyle jobs to use python3.8

### DIFF
--- a/jobs/builders/satellite6_automation_reports_builders.yaml
+++ b/jobs/builders/satellite6_automation_reports_builders.yaml
@@ -3,7 +3,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/builders/satellite6_capsule_sanity_check_builders.yaml
+++ b/jobs/builders/satellite6_capsule_sanity_check_builders.yaml
@@ -3,7 +3,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/builders/satellite6_consolidated_reports_builders.yaml
+++ b/jobs/builders/satellite6_consolidated_reports_builders.yaml
@@ -3,7 +3,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/builders/satellite6_provisioning_builders.yaml
+++ b/jobs/builders/satellite6_provisioning_builders.yaml
@@ -3,7 +3,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/builders/satellite6_standalone_automation_builders.yaml
+++ b/jobs/builders/satellite6_standalone_automation_builders.yaml
@@ -3,7 +3,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/builders/satellite6_upgrade_builders.yaml
+++ b/jobs/builders/satellite6_upgrade_builders.yaml
@@ -3,7 +3,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/builders/satellite6_upgrade_existence_builders.yaml
+++ b/jobs/builders/satellite6_upgrade_existence_builders.yaml
@@ -3,7 +3,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/builders/satellite6_upgrade_scenarios_builders.yaml
+++ b/jobs/builders/satellite6_upgrade_scenarios_builders.yaml
@@ -3,7 +3,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/builders/satellite6_upgrade_tiers_builders.yaml
+++ b/jobs/builders/satellite6_upgrade_tiers_builders.yaml
@@ -3,7 +3,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/capsule-installer.yaml
+++ b/jobs/capsule-installer.yaml
@@ -111,7 +111,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/custom-certs-automation.yaml
+++ b/jobs/custom-certs-automation.yaml
@@ -92,7 +92,7 @@
     builders:
           - shining-panda:
               build-environment: virtualenv
-              python-version: System-CPython-3.6
+              python-version: System-CPython-3.8
               clear: true
               nature: shell
               command:

--- a/jobs/robottelo-ci-update-jobs.yaml
+++ b/jobs/robottelo-ci-update-jobs.yaml
@@ -17,7 +17,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/satellite6-automation/satellite6-sanity.yaml
+++ b/jobs/satellite6-automation/satellite6-sanity.yaml
@@ -83,7 +83,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/satellite6-betelgeuse.yaml
+++ b/jobs/satellite6-betelgeuse.yaml
@@ -24,7 +24,7 @@
         - shining-panda:
             build-environment: virtualenv
             name: betelgeuse
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:
@@ -166,7 +166,7 @@
         - shining-panda:
             build-environment: virtualenv
             name: betelgeuse
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:
@@ -204,7 +204,7 @@
         - shining-panda:
             build-environment: virtualenv
             name: betelgeuse
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:
@@ -259,7 +259,7 @@
         - shining-panda:
             build-environment: virtualenv
             name: betelgeuse
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/satellite6-claim-failures.yml
+++ b/jobs/satellite6-claim-failures.yml
@@ -5,7 +5,7 @@
     - raw:
         xml: |
           <jenkins.plugins.shiningpanda.builders.VirtualenvBuilder plugin="shiningpanda@0.23">
-          <pythonName>System-CPython-3.6</pythonName>
+          <pythonName>System-CPython-3.8</pythonName>
           <home>claims</home>
           <clear>false</clear>
           <systemSitePackages>true</systemSitePackages>

--- a/jobs/satellite6-client-populate.yaml
+++ b/jobs/satellite6-client-populate.yaml
@@ -150,7 +150,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/satellite6-discovery-remaster.yaml
+++ b/jobs/satellite6-discovery-remaster.yaml
@@ -44,7 +44,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/satellite6-handle-tier-instances.yaml
+++ b/jobs/satellite6-handle-tier-instances.yaml
@@ -45,7 +45,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/satellite6-installer.yaml
+++ b/jobs/satellite6-installer.yaml
@@ -207,7 +207,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/satellite6-libvirt-install.yaml
+++ b/jobs/satellite6-libvirt-install.yaml
@@ -117,7 +117,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/satellite6-populate.yaml
+++ b/jobs/satellite6-populate.yaml
@@ -161,7 +161,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/satellite6-qe-environment-toggle.yaml
+++ b/jobs/satellite6-qe-environment-toggle.yaml
@@ -28,7 +28,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/satellite6-rcm-compose.yaml
+++ b/jobs/satellite6-rcm-compose.yaml
@@ -162,7 +162,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:

--- a/jobs/satellite6-upgrader.yaml
+++ b/jobs/satellite6-upgrader.yaml
@@ -137,7 +137,7 @@
     builders:
         - shining-panda:
             build-environment: virtualenv
-            python-version: System-CPython-3.6
+            python-version: System-CPython-3.8
             clear: true
             nature: shell
             command:


### PR DESCRIPTION
ShiningPanda is already prepared: 
executable `/usr/local/bin/python3.8` added as the new python installation named `System-CPython-3.8`
