### PR TITLE
Update pipeline jobs to use python3.8

### DIFF
--- a/vars/defaults.groovy
+++ b/vars/defaults.groovy
@@ -1,5 +1,5 @@
 class defaults implements Serializable {
-    String python = 'python3'
+    String python = 'python3.8'
     String venv = '.env'
     String venvModule = 'virtualenv'
 


### PR DESCRIPTION
Yet this is change for pipelines jobs.

Freestyle jobs are already handled by https://github.com/SatelliteQE/robottelo-ci/pull/1844