### PR TITLE
place all release pipelines more into the "real" night

### DIFF
--- a/jobs/release/sat-maintenance-next-release-pipeline.yaml
+++ b/jobs/release/sat-maintenance-next-release-pipeline.yaml
@@ -3,7 +3,7 @@
     project-type: pipeline
     sandbox: true
     triggers:
-      - timed: 'H 06 * * *'
+      - timed: 'H 9 30 * *'
     dsl:
       !include-raw:
         - workflows/maintenance-next/releasePipelineAttributes.groovy

--- a/jobs/release/sat-maintenance-release-pipeline.yaml
+++ b/jobs/release/sat-maintenance-release-pipeline.yaml
@@ -3,7 +3,7 @@
     project-type: pipeline
     sandbox: true
     triggers:
-      - timed: 'H 06 * * *'
+      - timed: 'H 9 * * *'
     dsl:
       !include-raw:
         - workflows/maintenance/releasePipelineAttributes.groovy

--- a/jobs/release/sat-release.yaml
+++ b/jobs/release/sat-release.yaml
@@ -62,16 +62,16 @@
           satellite_cron: ''
       - '66':
           satellite_dotted_version: '6.6'
-          satellite_cron: 'H 10 * * *'
+          satellite_cron: 'H 1 * * *'
       - '67':
           satellite_dotted_version: '6.7'
-          satellite_cron: 'H 8 * * *'
+          satellite_cron: 'H 3 * * *'
       - '68':
           satellite_dotted_version: '6.8'
-          satellite_cron: 'H 16 * * *'
+          satellite_cron: 'H 5 * * *'
       - '69':
           satellite_dotted_version: '6.9'
-          satellite_cron: 'H 13 * * *'
+          satellite_cron: 'H 7 * * *'
     jobs:
       - sat-{satellite_version}-release-pipeline
       - sat-{satellite_version}-release-qa


### PR DESCRIPTION
this makes the full EU and US day clear of automated pipelines, allowing
for manual runs more easily