### PR TITLE
drop rhel6-ppc64 from 6.8 tools

### DIFF
--- a/workflows/6.8/releasePipelineAttributes.groovy
+++ b/workflows/6.8/releasePipelineAttributes.groovy
@@ -28,7 +28,6 @@ def tools_repositories = [
     "Satellite Tools ${satellite_main_version} RHEL7 aarch64",
     "Satellite Tools ${satellite_main_version} RHEL6 x86_64",
     "Satellite Tools ${satellite_main_version} RHEL6 i386",
-    "Satellite Tools ${satellite_main_version} RHEL6 ppc64",
     "Satellite Tools ${satellite_main_version} RHEL6 s390x",
     "Satellite Tools ${satellite_main_version} RHEL5 x86_64",
     "Satellite Tools ${satellite_main_version} RHEL5 i386",


### PR DESCRIPTION
RHEL6 enters ELS phase soon, and ppc64 is not supported then anymore