### PR TITLE
migration to RPv5 - switch the default branch to master

### DIFF
--- a/jobs/satellite6-report-portal.yaml
+++ b/jobs/satellite6-report-portal.yaml
@@ -18,7 +18,7 @@
             default: 'satelliteqe'
         - string:
             name: RP_TOOLS_BRANCH
-            default: 'RPv4'
+            default: 'master'
         - string:
             name: WORKERS
             default: '8'


### PR DESCRIPTION
Since we're no longer pushing data to v4 report portal, let's switch the default branch back to `master`