### PR TITLE
drop rhel6-ppc64 from 6.6 and 6.7 tools

### DIFF
--- a/workflows/6.6/releasePipelineAttributes.groovy
+++ b/workflows/6.6/releasePipelineAttributes.groovy
@@ -29,7 +29,6 @@ def tools_repositories = [
     "Satellite Tools ${satellite_main_version} RHEL7 aarch64",
     "Satellite Tools ${satellite_main_version} RHEL6 x86_64",
     "Satellite Tools ${satellite_main_version} RHEL6 i386",
-    "Satellite Tools ${satellite_main_version} RHEL6 ppc64",
     "Satellite Tools ${satellite_main_version} RHEL6 s390x",
     "Satellite Tools ${satellite_main_version} RHEL5 x86_64",
     "Satellite Tools ${satellite_main_version} RHEL5 i386",

--- a/workflows/6.7/releasePipelineAttributes.groovy
+++ b/workflows/6.7/releasePipelineAttributes.groovy
@@ -28,7 +28,6 @@ def tools_repositories = [
     "Satellite Tools ${satellite_main_version} RHEL7 aarch64",
     "Satellite Tools ${satellite_main_version} RHEL6 x86_64",
     "Satellite Tools ${satellite_main_version} RHEL6 i386",
-    "Satellite Tools ${satellite_main_version} RHEL6 ppc64",
     "Satellite Tools ${satellite_main_version} RHEL6 s390x",
     "Satellite Tools ${satellite_main_version} RHEL5 x86_64",
     "Satellite Tools ${satellite_main_version} RHEL5 i386",


### PR DESCRIPTION
RHEL6 is ELS, and ppc64 is not supported there