### PR TITLE
Revert "Pin ansible version.  2.9+ no longer installs on py27"

### DIFF
--- a/ansible/ansible-requirements.txt
+++ b/ansible/ansible-requirements.txt
@@ -1,2 +1,2 @@
-ansible==2.8
+ansible
 apypie


### PR DESCRIPTION
Apparently we were stuck in a weird release window.  2.10 now installs on py27

This reverts commit fd5f0923e3ab38d885643d3e7f1b69f7b03818a5.