### PR TITLE
Set strict_host_check to false in ansible config

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -5,3 +5,4 @@ verbosity = 1
 inventory = inventory
 collections_paths = collections
 retry_files_enabled = False
+strict_host_checking = False


### PR DESCRIPTION
When using the ssh agent plugin in Jenkins this needs to be set for Ansible to ssh to other systems properly.