### PR TITLE
DONTMERGE: Add --include-stubbed pytest option

### DIFF
--- a/jobs/satellite6-standalone-automation.yaml
+++ b/jobs/satellite6-standalone-automation.yaml
@@ -61,9 +61,9 @@
                 parameter will be ignored</strong>.</p>
         - string:
             name: PYTEST_MARKS
-            default: stubbed
+            default: 
             description: |
-                Specify the py.test marks you want to run or skip when specifying PYTEST_OPTIONS.
+                Specify the -m option to filter pytest collection. INCLUDE `-m`, for example `-m destructive`
         - string:
             name: ROBOTTELO_REPO
             default: https://github.com/SatelliteQE/robottelo.git

--- a/scripts/satellite6-standalone-automation.sh
+++ b/scripts/satellite6-standalone-automation.sh
@@ -38,7 +38,7 @@ env =
    PYTHONHASHSEED=0
 
 pytest() {
-    $(which py.test) -v --junit-xml=foreman-results.xml -o junit_suite_name=standalone-automation -m "${PYTEST_MARKS}" "$@"
+    $(which py.test) -v --junit-xml=foreman-results.xml -o junit_suite_name=standalone-automation "${PYTEST_MARKS}" "$@"
 }
 
 if [ -n "${PYTEST_OPTIONS:-}" ]; then

--- a/scripts/satellite6-upgrade-tier-source.sh
+++ b/scripts/satellite6-upgrade-tier-source.sh
@@ -86,6 +86,7 @@ if [ "${ENDPOINT}" != "end-to-end" ]; then
     $(which py.test) -v --junit-xml="${ENDPOINT}-upgrade-sequential-results.xml" \
         -o junit_suite_name="${ENDPOINT}-upgrade-sequential" \
         -m "upgrade and run_in_one_thread" \
+        --include-stubbed \
         ${TEST_TYPE}
 
     # Run all tiers parallel tests with upgrade mark
@@ -93,6 +94,7 @@ if [ "${ENDPOINT}" != "end-to-end" ]; then
     $(which py.test) -v --junit-xml="${ENDPOINT}-upgrade-parallel-results.xml" -n "${ROBOTTELO_WORKERS}" \
         -o junit_suite_name="${ENDPOINT}-upgrade-parallel" \
         -m "upgrade and not run_in_one_thread" \
+        --include-stubbed \
         ${TEST_TYPE}
     set -e
 elif [ "${ENDPOINT}" == "end-to-end" ]; then

--- a/workflows/qe/satellite6-automation/satellite6-tiers.groovy
+++ b/workflows/qe/satellite6-automation/satellite6-tiers.groovy
@@ -267,6 +267,7 @@ stages {
           $(which py.test) -v --junit-xml="${ENDPOINT}-sequential-results.xml" \
             -o junit_suite_name="${ENDPOINT}-sequential" \
             -m "${ENDPOINT} and run_in_one_thread ${EXTRA_MARKS}" \
+            --include-stubbed \
             --ibutsu ${IBUTSU_SERVER} \
             --ibutsu-project ${IBUTSU_PROJECT} \
             --ibutsu-source ${ENDPOINT}-sequential \
@@ -291,6 +292,7 @@ stages {
           $(which py.test) -v --junit-xml="${ENDPOINT}-parallel-results.xml" -n "${ROBOTTELO_WORKERS}" \
             -o junit_suite_name="${ENDPOINT}-parallel" \
             -m "${ENDPOINT} and not run_in_one_thread ${EXTRA_MARKS}" \
+            --include-stubbed \
             ${TEST_TYPE}
           set -e
         '''


### PR DESCRIPTION
Adjust standalone automation mark option so that a default value is not
required.

https://github.com/SatelliteQE/robottelo/pull/8395

This robottelo PR will modify default collection behavior to not include
stubbed test cases.

The pipelines are currently including stubbed cases by default, this
will keep them collected so that they're uploaded to polarion