### PR TITLE
Freeze old CI to use 6.9.freeze instead of master

### DIFF
--- a/jobs/satellite6-automation/satellite6-projects.yaml
+++ b/jobs/satellite6-automation/satellite6-projects.yaml
@@ -12,9 +12,11 @@
             scm-branch: origin/6.7.z
         - '6.8':
               scm-branch: origin/6.8.z
-        - '6.9'
+        - '6.9':
+              scm-branch: origin/6.9.freeze
         - 'upstream-nightly':
-            rp_project: 'katello-nightly'
+              scm-branch: origin/6.9.freeze
+              rp_project: 'katello-nightly'
     os:
         - 'rhel7'
         - 'rhel8'
@@ -80,7 +82,8 @@
             scm-branch: origin/6.7.z
         - '6.8':
             scm-branch: origin/6.8.z
-        - '6.9'
+        - '6.9':
+            scm-branch: origin/6.9.freeze
     os:
         - 'rhel7'
     jobs:

--- a/lib/python/satellite6-polarion-test-case-inject.py
+++ b/lib/python/satellite6-polarion-test-case-inject.py
@@ -30,11 +30,13 @@ def get_product_versions(repo, test_path, tmp_path, xml_file_path):
     # Get all branches of cloned repo
     get_repo(url=repo, tmp_path=tmp_path)
     branches = get_all_branches(tmp_path + "/.git")
-    satellite_stable_branches = re.findall(r"origin/6.*", branches.decode('utf-8'))
+    # FREEZE: care only about 6.2.z..6.8.z branches
+    satellite_stable_branches = re.findall(r"origin/6\.[2-8].*", branches.decode('utf-8'))
 
     satellite_stable_branches = [
         name.replace("origin/", " ").strip() for name in satellite_stable_branches]
-    satellite_stable_branches.append('master')
+    # FREEZE: 6.9.freeze branch replaces master
+    satellite_stable_branches.append('6.9.freeze')
     previous_directory = os.getcwd()
     os.chdir(tmp_path)
 
@@ -65,15 +67,16 @@ def get_product_versions(repo, test_path, tmp_path, xml_file_path):
         versions = []
         for branches_name in satellite_stable_branches:
             if tc_id in dict[branches_name]:
-                if branches_name == "master":
-                    # Replace master with respective product version it points to
-                    master_branch_sat_version = float(max([x.replace(
-                        ".z", "") for x in satellite_stable_branches if x != "master"])) + 0.1
-                    master_branch_sat_version = round(master_branch_sat_version, 1)
-                    versions.append(branches_name.replace(
-                        "master", str(master_branch_sat_version)))
-                else:
-                    versions.append(branches_name.replace(".z", ""))
+                # FREEZE: 6.9.freeze branch replaces master
+                # if branches_name == "master":
+                #     # Replace master with respective product version it points to
+                #     master_branch_sat_version = float(max([x.replace(
+                #         ".z", "") for x in satellite_stable_branches if x != "master"])) + 0.1
+                #     master_branch_sat_version = round(master_branch_sat_version, 1)
+                #     versions.append(branches_name.replace(
+                #         "master", str(master_branch_sat_version)))
+                # else:
+                versions.append('.'.join(branches_name.split('.')[:2]))
         dict1[tc_id] = ", ".join(versions)
 
     os.chdir(previous_directory)

--- a/vars/branch_selection.groovy
+++ b/vars/branch_selection.groovy
@@ -6,11 +6,10 @@
 */
 def call(String satellite_version='6.9') {
     branch_map=[
-        "6.5": "6.5.z",
         "6.6": "6.6.z",
         "6.7": "6.7.z",
         "6.8": "6.8.z",
     ]
-    def branch = satellite_version in branch_map ? branch_map[satellite_version] : "master"
+    def branch = satellite_version in branch_map ? branch_map[satellite_version] : "6.9.freeze"
     return branch
 }


### PR DESCRIPTION
- freeze 6.9 to use `6.9.freeze` branch
   -  freestyle jobs by jjb 
   -  pipeline jobs by library change 
- change `satellite6-polarion-test-case-inject.py` to avoid `master` branch 