### PR TITLE
Disable polarion-test-case job in old CI

### DIFF
--- a/jobs/satellite6-betelgeuse.yaml
+++ b/jobs/satellite6-betelgeuse.yaml
@@ -1,5 +1,6 @@
 - job:
     name: polarion-test-case
+    disabled: true
     node: sat6-rhel
     scm:
         - git:


### PR DESCRIPTION
We need to disable test-case data uploads from old CI to avoid overwriting in Polarion production instance.