### PR TITLE
Disable all 6.9 tiers jobs

### DIFF
--- a/jobs/satellite6-automation/satellite6-projects.yaml
+++ b/jobs/satellite6-automation/satellite6-projects.yaml
@@ -14,6 +14,7 @@
               scm-branch: origin/6.8.z
         - '6.9':
               scm-branch: origin/6.9.freeze
+              disabled: true
         - 'upstream-nightly':
               scm-branch: origin/6.9.freeze
               rp_project: 'katello-nightly'


### PR DESCRIPTION
6.9 tiers jobs were obsoleted by new CI importance jobs.
We no longer need to run them.

    jobs:
        - provisioning-6.9-rhel7
        - automation-6.9-trigger-tiers-rhel7
        - automation-6.9-tier1-rhel7
        - automation-6.9-tier2-rhel7
        - automation-6.9-tier3-rhel7
        - automation-6.9-tier4-rhel7
        - automation-6.9-rhai-rhel7
        - automation-6.9-destructive-rhel7
        - polarion-test-run-6.9-rhel7
        - polarion-trigger-6.9-rhel7
        - report-automation-results-6.9-rhel7
        - report-consolidated-coverage-6.9-rhel7
