### PR TITLE
Fix disabling 6.9 tiers jobs

### DIFF
--- a/jobs/satellite6-automation/satellite6-polarion.yaml
+++ b/jobs/satellite6-automation/satellite6-polarion.yaml
@@ -39,6 +39,7 @@
 - job-template:
     name: polarion-trigger-{satellite_version}-{os}
     project-type: multijob
+    disabled: {disabled}
     node: sat6-{satellite_version}
     parameters:
         - string:
@@ -115,6 +116,7 @@
 
 - job-template:
     name: polarion-test-run-{satellite_version}-{os}
+    disabled: {disabled}
     node: sat6-{satellite_version}
     scm:
         - git:

--- a/jobs/satellite6-automation/satellite6-projects.yaml
+++ b/jobs/satellite6-automation/satellite6-projects.yaml
@@ -5,6 +5,7 @@
     name: satellite6-automation
     scm-branch: origin/master
     rp_project: 'satellite6'
+    disabled: false
     satellite_version:
         - '6.6':
             scm-branch: origin/6.6.z

--- a/jobs/satellite6-automation/satellite6-reporting.yaml
+++ b/jobs/satellite6-automation/satellite6-reporting.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'report-automation-results-{satellite_version}-{os}'
     project-type: pipeline
+    disabled: {disabled}
     sandbox: true
     parameters:
       - string:
@@ -23,6 +24,7 @@
 
 - job-template:
     name: 'report-consolidated-coverage-{satellite_version}-{os}'
+    disabled: {disabled}
     node: sat6-{satellite_version}
     parameters:
         - satellite6-automation-parameters

--- a/jobs/satellite6-automation/satellite6-tiers.yaml
+++ b/jobs/satellite6-automation/satellite6-tiers.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: 'automation-{satellite_version}-trigger-tiers-{os}'
     project-type: multijob
+    disabled: {disabled}
     node: docker
     build-discarder:
         num-to-keep: 16
@@ -66,6 +67,7 @@
 - job-template:
     name: 'automation-{satellite_version}-{endpoint}-{os}'
     project-type: pipeline
+    disabled: {disabled}
     sandbox: true
     properties:
         - inject:


### PR DESCRIPTION
Now I understand JJB project attributes - they are arbitrary - it can be anything (not just job attributes)

Complements incomplete PR https://github.com/SatelliteQE/robottelo-ci/pull/1920