### PR TITLE
Remove useless polarion upgrade testrun suffix

### DIFF
--- a/scripts/satellite6-betelgeuse-test-run.sh
+++ b/scripts/satellite6-betelgeuse-test-run.sh
@@ -31,7 +31,6 @@ TEST_RUN_GROUP_ID="$(echo ${TEST_RUN_ID} | cut -d' ' -f2)"
 # Prepare the XML files
 
 if [[ "${TEST_RUN_ID}" = *"upgrade"* ]]; then
-    TEST_RUN_ID="${TEST_RUN_ID} - Upgrade"
     # All tiers result upload
     for run in parallel sequential; do
         betelgeuse ${TOKEN_PREFIX} test-run \


### PR DESCRIPTION
Currently the script produces testrun named:
`Satellite 6.9.2-1.0 rhel7 upgrade - Upgrade`   

This PR removes useless `- Upgrade` suffix