### PR TITLE
Remove stage to trigger disabled polarion-test-case

### DIFF
--- a/workflows/qe/satellite6-automation/satellite6-trigger.groovy
+++ b/workflows/qe/satellite6-automation/satellite6-trigger.groovy
@@ -73,18 +73,6 @@ pipeline {
       }
      }
     }
-    stage("Trigger Polarion test Case job") {
-     steps {
-      script {
-       build job: "polarion-test-case",
-        parameters: [
-         string(name: 'SATELLITE_VERSION', value: "${satellite_version}"),
-        ],
-        propagate: false,
-        wait: true
-      }
-     }
-    }
     stage("Trigger Sanity job for rhel7") {
      when {
       expression {


### PR DESCRIPTION
`polarion-test-case` was disabled but there is still stage that tries to trigger the disabled job and makes `trigger-satellite-6.9` job to always fail
